### PR TITLE
Fix Rails 5.0 check for tag_options

### DIFF
--- a/lib/wice/wice_grid_core_ext.rb
+++ b/lib/wice/wice_grid_core_ext.rb
@@ -113,7 +113,7 @@ module ActionView #:nodoc:
   module Helpers #:nodoc:
     module TagHelper #:nodoc:
       def public_tag_options(options, escape = true) #:nodoc:
-        if respond_to?(:tag_options)
+        if respond_to?(:tag_options, true)
           tag_options(options, escape)
         else
           tag_builder.tag_options(options, escape)


### PR DESCRIPTION
`tag_options` is private in Rails 5.0 and so is not found by `respond_to?` unless you tell it to include all methods.