### PR TITLE
custom_sort option for model-based sorting

### DIFF
--- a/lib/wice/columns.rb
+++ b/lib/wice/columns.rb
@@ -99,7 +99,7 @@ module Wice #:nodoc:
 
       # fields defined from the options parameter
       FIELDS = [:attribute, :name, :html, :filter, :model, :allow_multiple_selection,
-                :in_html, :in_csv, :table_alias, :custom_order, :detach_with_id, :ordering, :auto_reload]
+                :in_html, :in_csv, :table_alias, :custom_order, :detach_with_id, :ordering, :auto_reload, :custom_sort]
 
       attr_accessor(*FIELDS)
 
@@ -205,7 +205,7 @@ module Wice #:nodoc:
       end
 
       def fully_qualified_attribute_name #:nodoc:
-        table_alias_or_table_name + '.' + attribute
+        table_alias_or_table_name ? (table_alias_or_table_name + '.' + attribute) : nil
       end
 
       def filter_shown? #:nodoc:

--- a/lib/wice/grid_renderer.rb
+++ b/lib/wice/grid_renderer.rb
@@ -313,7 +313,8 @@ module Wice
         name:                        '',
         negation:                    ConfigurationProvider.value_for(:NEGATION_IN_STRING_FILTERS),
         ordering:                    true,
-        table_alias:                 nil
+        table_alias:                 nil,
+        custom_sort:                 nil,
       }
 
       opts.assert_valid_keys(options.keys)
@@ -375,7 +376,8 @@ module Wice
           custom_filter_active: options[:custom_filter],
           table_alias:          options[:table_alias],
           filter_type:          options[:filter_type],
-          assocs:               assocs
+          assocs:               assocs,
+          custom_sort:          options[:custom_sort],
         )
 
         # [ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::Column, String, Boolean]
@@ -567,7 +569,7 @@ module Wice
     end
 
     def column_link(column, direction, params, extra_parameters = {})   #:nodoc:
-      column_attribute_name = if column.attribute.index('.') || column.main_table
+      column_attribute_name = if column.attribute.index('.') || column.main_table || column.table_alias_or_table_name.nil?
         column.attribute
       else
         column.table_alias_or_table_name + '.' + column.attribute

--- a/lib/wice/helpers/wice_grid_view_helpers.rb
+++ b/lib/wice/helpers/wice_grid_view_helpers.rb
@@ -294,7 +294,7 @@ module Wice
 
         Wice::WgHash.add_or_append_class_value!(opts, column.css_class)
 
-        if column.attribute && column.ordering
+        if column.attribute && (column.ordering || column.custom_sort)
 
           column.add_css_class('active-filter') if grid.filtered_by?(column)
 

--- a/lib/wice/wice_grid_core_ext.rb
+++ b/lib/wice/wice_grid_core_ext.rb
@@ -113,7 +113,7 @@ module ActionView #:nodoc:
   module Helpers #:nodoc:
     module TagHelper #:nodoc:
       def public_tag_options(options, escape = true) #:nodoc:
-        if respond_to?(:tag_options)
+        if respond_to?(:tag_options, true)
           tag_options(options, escape)
         else
           tag_builder.tag_options(options, escape)


### PR DESCRIPTION
This adds the ability to sort the grid by an arbitrary model attribute or calculation. To enable this feature, add an `attribute` option to the column definition (does not need to be a column - will just be used as a parameter name) and a `custom_sort` option. `custom_sort` should be a lambda that accepts the model and returns the value to be sorted on.

For example, if you are writing blogging software and wish to display the number of public posts an author has, it is not easy to be able to sort by this column if it is not an attribute in the authors table. With `custom_sort`, you can do:

```ruby
  g.column name: 'Public Posts', attribute: 'public_posts', custom_sort: ->(author) { author.posts.public.count } do |author|
    author.posts.public.count
  end
```

and sorting will be enabled on that column.

`custom_sort` has the same kind of drawback as `custom_filter`. When the sort is active, all results (not just those on the current page) will be loaded by ActiveRecord, and the calculation will be performed on all results. As such, it is not recommended if you have lots of results or if the calculation is expensive.

I can add documentation if the code changes look acceptable.