### PR TITLE
Fix 'render text:' deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Add option `filter_control_options` to columns. Initial use is to pass in the options `start_year`, `end_year`, and `max_year_allowed` when using `rails_datetime_helper` - [#12](https://github.com/patricklindsay/wice_grid/pull/18)
+* Fix deprecation (in Rails 5.0.x) and incorrect behaviour (in Rails 5.1.x) of CSV exports
 
 ## 4.0.1 (31 May, 2018)
 

--- a/lib/wice/wice_grid_controller.rb
+++ b/lib/wice/wice_grid_controller.rb
@@ -179,7 +179,7 @@ module Wice
       @performed_render = false
 
       logger.info "Sending file #{path}" unless logger.nil?
-      File.open(path, 'rb') { |file| render status: options[:status], text: file.read }
+      File.open(path, 'rb') { |file| render status: options[:status], plain: file.read }
     end
 
     DEFAULT_SEND_FILE_OPTIONS_RAILS2 = { #:nodoc:

--- a/spec/features/csv_export_request_spec.rb
+++ b/spec/features/csv_export_request_spec.rb
@@ -7,12 +7,8 @@ describe 'CSV export WiceGrid', type: :request, js: true do
   end
 
   it 'should export csv' do
-    # no idea how to test these
-
-    # find(:css, 'button.wg-external-csv-export-button').click
-
-    select 'Urgent', from: 'g1_f_priority_id'
-
-    # find(:css, 'button.div.clickable.export-to-csv-button').click
+    find(:css, 'button.wg-external-csv-export-button').click
+    sleep 1
+    expect(page.body).to include('ID;Title;Priority;Status;Project Name;')
   end
 end


### PR DESCRIPTION
```
DEPRECATION WARNING: `render :text` is deprecated because it does not actually render a `text/plain` response. Switch to `render plain: 'plain text'` to render as `text/plain`, `render html: '<strong>HTML</strong>'` to render as `text/html`, or `render body: 'raw'` to match the deprecated behavior and render with the default Content-Type, which is `text/plain`. (called from block in send_file_rails2 at /Users/jasonbarnabe/.rvm/gems/ruby-2.3.1/bundler/gems/wice_grid-9e87e0369f04/lib/wice/wice_grid_controller.rb:182)
```