### PR TITLE
Init wice grid on turbolinks page load event

### DIFF
--- a/vendor/assets/javascripts/wice_grid_init.js.coffee
+++ b/vendor/assets/javascripts/wice_grid_init.js.coffee
@@ -1,5 +1,5 @@
-$(document).on 'page:load ready', -> initWiceGrid()
-$(document).on 'turbolinks:load', -> initWiceGrid()
+$ -> initWiceGrid()
+$(document).on 'turbolinks:render', -> initWiceGrid()
 
 globalVarForAllGrids = 'wiceGrids'
 

--- a/vendor/assets/javascripts/wice_grid_init.js.coffee
+++ b/vendor/assets/javascripts/wice_grid_init.js.coffee
@@ -1,5 +1,5 @@
 $(document).on 'page:load ready', -> initWiceGrid()
-$(document).on 'turbolinks:render', -> initWiceGrid()
+$(document).on 'turbolinks:load', -> initWiceGrid()
 
 globalVarForAllGrids = 'wiceGrids'
 


### PR DESCRIPTION
Columns with `auto_reload: true` on them are not working on initial page load. This looks to be because:

> Turbolinks overrides the normal page loading process

(http://guides.rubyonrails.org/working_with_javascript_in_rails.html#page-change-events)

So attach `initWiceGrid` callback to the `turbolinks:load` event instead of the
`turbolinks:render` event.

The `turbolinks:render` event only fires when the page is updated. The `turbolinks:load` event is fired after each page change, which includes the initial page load.

From the turbolinks source:
```
translateEvent from: "turbolinks:render", to: "page:update"
translateEvent from: "turbolinks:load", to: "page:change"
```
(https://github.com/turbolinks/turbolinks/blob/c73e134731ad12b2ee987080f4c905aaacdebba1/src/turbolinks/compatibility.coffee#L16-L17)

---
P.S Thanks for updating wice to work with rails 5 @patricklindsay :)
