### PR TITLE
Use Capybara negation matchers

### DIFF
--- a/spec/features/action_column_request_spec.rb
+++ b/spec/features/action_column_request_spec.rb
@@ -27,7 +27,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should_not have_content('Selected tasks: 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, and 526')
+    page.should have_no_content('Selected tasks: 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, and 526')
   end
 
   it 'should filter by ID inside a form, two limits' do
@@ -229,7 +229,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should_not have_content('sed impedit iste')
+    page.should have_no_content('sed impedit iste')
   end
 
   it 'should reload the title filter' do

--- a/spec/features/all_records_request_spec.rb
+++ b/spec/features/all_records_request_spec.rb
@@ -8,7 +8,7 @@ describe 'all records WiceGrid', type: :request, js: true do
 
   it 'should filter by custom filters' do
     within 'div.wice-grid-container table.wice-grid tbody' do
-      page.should_not have_content('show all')
+      page.should have_no_content('show all')
     end
 
     within '.pagination_status' do

--- a/spec/features/auto_reloads2_request_spec.rb
+++ b/spec/features/auto_reloads2_request_spec.rb
@@ -298,7 +298,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
 
     find(:css, '#grid_f_title_n').click
 
-    page.should_not have_content('sed impedit iste')
+    page.should have_no_content('sed impedit iste')
   end
 
   it 'should reload the title filter' do

--- a/spec/features/auto_reloads_request_spec.rb
+++ b/spec/features/auto_reloads_request_spec.rb
@@ -302,7 +302,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
 
     find(:css, '#grid_f_title_n').click
 
-    page.should_not have_content('sed impedit iste')
+    page.should have_no_content('sed impedit iste')
   end
 
   it 'should reload the title filter' do

--- a/spec/features/basics6_request_spec.rb
+++ b/spec/features/basics6_request_spec.rb
@@ -16,7 +16,7 @@ describe 'basisc5 WiceGrid',  js: true do
     click_on 'show all'
 
     within 'div.wice-grid-container table.wice-grid tbody' do
-      page.should_not have_content('Yes')
+      page.should have_no_content('Yes')
     end
   end
 end

--- a/spec/features/hiding_checkboxes_in_action_column_request_spec.rb
+++ b/spec/features/hiding_checkboxes_in_action_column_request_spec.rb
@@ -40,7 +40,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should_not have_content('Selected tasks: 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 520, 521, 522, 523, 524, 525, and 526')
+    page.should have_no_content('Selected tasks: 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 520, 521, 522, 523, 524, 525, and 526')
   end
 
   it 'should keep the state of filter inside a form' do
@@ -253,7 +253,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should_not have_content('sed impedit iste')
+    page.should have_no_content('sed impedit iste')
   end
 
   it 'should reload the title filter' do

--- a/spec/features/negation_request_spec.rb
+++ b/spec/features/negation_request_spec.rb
@@ -18,6 +18,6 @@ describe 'negation WiceGrid', type: :request, js: true do
 
     find(:css, '#grid_submit_grid_icon').click
 
-    page.should_not have_content('sed impedit iste')
+    page.should have_no_content('sed impedit iste')
   end
 end

--- a/spec/features/shared.rb
+++ b/spec/features/shared.rb
@@ -48,7 +48,7 @@ shared_examples 'basic task table specs' do
 
         page.should have_content('2')
         page.should have_content('3')
-        page.should_not have_content('4')
+        page.should have_no_content('4')
       end
     end
   end


### PR DESCRIPTION
`page.should_not have_content` -> `page.should have_no_content`

This way, Capybara will wait a bit for the condition to become true, which will handle asynchronous JavaScript. This fixes a couple tests.