### PR TITLE
Use rails built in send_file method

### DIFF
--- a/lib/wice/wice_grid_controller.rb
+++ b/lib/wice/wice_grid_controller.rb
@@ -170,55 +170,5 @@ module Wice
         csv_encoding.split(':').first
       end
     end
-
-    def send_file_rails2(path, options = {}) #:nodoc:
-      raise "Cannot read file #{path}" unless File.file?(path) && File.readable?(path)
-
-      options[:length] ||= File.size(path)
-      options[:filename] ||= File.basename(path) unless options[:url_based_filename]
-      send_file_headers_rails2! options
-
-      @performed_render = false
-
-      logger.info "Sending file #{path}" unless logger.nil?
-      File.open(path, 'rb') { |file| render status: options[:status], plain: file.read }
-    end
-
-    DEFAULT_SEND_FILE_OPTIONS_RAILS2 = { #:nodoc:
-      type:         'application/octet-stream'.freeze,
-      disposition:  'attachment'.freeze,
-      stream:       true,
-      buffer_size:  4096,
-      x_sendfile:   false
-    }.freeze
-
-    def send_file_headers_rails2!(options) #:nodoc:
-      options.update(DEFAULT_SEND_FILE_OPTIONS_RAILS2.merge(options))
-      [:length, :type, :disposition].each do |arg|
-        raise ArgumentError, ":#{arg} option required" if options[arg].nil?
-      end
-
-      disposition = options[:disposition].dup || 'attachment'
-
-      disposition <<= %(; filename="#{options[:filename]}") if options[:filename]
-
-      content_type = options[:type]
-      content_type = content_type.to_s.strip # fixes a problem with extra '\r' with some browsers
-
-      headers.merge!(
-        'Content-Length'            => options[:length].to_s,
-        'Content-Type'              => content_type,
-        'Content-Disposition'       => disposition,
-        'Content-Transfer-Encoding' => 'binary'
-      )
-
-      # Fix a problem with IE 6.0 on opening downloaded files:
-      # If Cache-Control: no-cache is set (which Rails does by default),
-      # IE removes the file it just downloaded from its cache immediately
-      # after it displays the "open/save" dialog, which means that if you
-      # hit "open" the file isn't there anymore when the application that
-      # is called for handling the download is run, so let's workaround that
-      headers['Cache-Control'] = 'private' if headers['Cache-Control'] == 'no-cache'
-    end
   end
 end

--- a/lib/wice/wice_grid_controller.rb
+++ b/lib/wice/wice_grid_controller.rb
@@ -115,7 +115,7 @@ module Wice
         temp_filename = temp_filename.strip
         filename = (grid.csv_file_name || grid.name) + '.csv'
         grid.csv_tempfile.close
-        send_file_rails2 temp_filename, filename: filename, type: "text/csv; charset=#{get_output_encoding grid.csv_encoding}"
+        send_file temp_filename, filename: filename, type: "text/csv; charset=#{get_output_encoding grid.csv_encoding}"
         grid.csv_tempfile = nil
         true
       else


### PR DESCRIPTION
In Rails 5.1.3 the csv export was not outputting the table contents, it was trying to render the layout file but in a CSV format:

<img width="967" alt="screen shot 2018-05-23 at 14 09 58" src="https://user-images.githubusercontent.com/191664/40426457-0b4ae994-5e93-11e8-9eca-6361a40b9c26.png">

The proposed fix is to use the Rails `send_file` method over `send_file_rails2` which is defined in wice grid itself (and called by `export_grid_if_requested`).

I'm not too sure what it would take to get the `send_file_rails2` method updated to work alongside the rails one: https://github.com/rails/rails/blob/375a4143cf5caeb6159b338be824903edfd62836/actionpack/lib/action_controller/metal/data_streaming.rb#L67 or what specifically was breaking / missing from the `send_file_rails2` if we do need to keep it around.

This change resulted in the CSV export function working as expected. It will be interesting to see if the tests are still passing with the `send_file` method once the testbed has been ported over. If we can adopt the rails method then a good chunk of this controller code (`lib/wice/wice_grid_controller.rb`) could be deleted.