### PR TITLE
Add new option filter_control_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add option `filter_control_options` to columns. Initial use is to pass in the options `start_year`, `end_year`, and `max_year_allowed` when using `rails_datetime_helper` - [#12](https://github.com/patricklindsay/wice_grid/pull/18)
+
 ## 4.0.1 (31 May, 2018)
 
 * Fixed tagbuilder issue with Rails 5.0.x - [#1](https://github.com/patricklindsay/wice_grid/pull/1)

--- a/lib/wice/columns.rb
+++ b/lib/wice/columns.rb
@@ -99,7 +99,8 @@ module Wice #:nodoc:
 
       # fields defined from the options parameter
       FIELDS = [:attribute, :name, :html, :filter, :model, :allow_multiple_selection,
-                :in_html, :in_csv, :table_alias, :custom_order, :detach_with_id, :ordering, :auto_reload]
+                :in_html, :in_csv, :table_alias, :custom_order, :detach_with_id, :ordering, :auto_reload,
+                :filter_control_options]
 
       attr_accessor(*FIELDS)
 
@@ -123,6 +124,9 @@ module Wice #:nodoc:
 
       # A boolean flag: whether a column has a text input or not
       attr_reader :contains_a_text_input
+
+      # options for rendering filter controls. Supported options are specific to the type.
+      attr_accessor :filter_control_options
 
       def initialize(block, options, grid_obj, tname, mtable, cfilter, view)  #:nodoc:
         self.cell_rendering_block = block

--- a/lib/wice/columns/column_rails_datetime_helper.rb
+++ b/lib/wice/columns/column_rails_datetime_helper.rb
@@ -11,9 +11,10 @@ module Wice
       end
 
       def do_render(params) #:nodoc:
+        datetime_options = filter_control_options ? filter_control_options.slice(:start_year, :end_year, :max_year_allowed) : {}
         '<div class="date-filter">' +
-          select_datetime(params[:fr], include_blank: true, prefix: @name1) + '<br/>' +
-          select_datetime(params[:to], include_blank: true, prefix: @name2) +
+          select_datetime(params[:fr], datetime_options.merge(include_blank: true, prefix: @name1)) + '<br/>' +
+          select_datetime(params[:to], datetime_options.merge(include_blank: true, prefix: @name2)) +
           '</div>'
       end
 

--- a/lib/wice/grid_renderer.rb
+++ b/lib/wice/grid_renderer.rb
@@ -215,6 +215,9 @@ module Wice
     # * <tt>:filter_type</tt> - Using a column filter different from the default filter chosen automatically based on the
     #   data type or the <tt>:custom_filter</tt> argument. See <tt>lib/columns/column_processor_index.rb</tt> for the
     #   list of available filters.
+    # * <tt>:filter_control_options</tt> - Additional options to pass to the filter class to change the filter control
+    #   behaviour. Supported options are dependent on the filter used.
+    #   This is needed if sorting is required while  filters are not.
     # * <tt>:ordering</tt> - Enable/disable ordering links in the column titles. The default is +true+
     #   (i.e. if <tt>:attribute</tt> is defined, ordering is enabled)
     # * <tt>:assoc</tt> - Name of the model association. <tt>:attribute</tt> belongs to the table joined via this association.
@@ -305,6 +308,7 @@ module Wice
         detach_with_id:              nil,
         filter:                      true,
         filter_all_label:            ConfigurationProvider.value_for(:CUSTOM_FILTER_ALL_LABEL),
+        filter_control_options:      {},
         filter_type:                 nil,
         html:                        {},
         in_csv:                      true,

--- a/spec/support/test_app/app/views/dates/_grid.html.erb
+++ b/spec/support/test_app/app/views/dates/_grid.html.erb
@@ -17,7 +17,7 @@
     task.created_at.to_s(:db)
   end
 
-  g.column name:  'Updated', attribute: 'updated_at', filter_type: :rails_datetime_helper do |task|
+  g.column name:  'Updated', attribute: 'updated_at', filter_type: :rails_datetime_helper, filter_control_options: {start_year: 2011} do |task|
     task.updated_at.to_s(:db)
   end
 


### PR DESCRIPTION
Pass filter_control_options to the filter controls. Add support for start_year, end_year, max_year_allowed passed to rails_datetime_helper. This is required to fix a test that failed because the text wanted to filter on year 2011 but by default the options went to current year - 5