### PR TITLE
Fix flakiness in saved_queries_request_spec.rb

### DIFF
--- a/spec/features/saved_queries_request_spec.rb
+++ b/spec/features/saved_queries_request_spec.rb
@@ -9,8 +9,9 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
   def delete_all_saved_queries(context)
     while delete_link = context.find(:css, '.wice-grid-delete-query')
       delete_link.click
+      expect(page).to have_selector('#grid_notification_messages', text: 'Saved query deleted.')
     end
-  rescue Capybara::ElementNotFound, Selenium::WebDriver::Error::StaleElementReferenceError
+  rescue Capybara::ElementNotFound
     true
   end
 


### PR DESCRIPTION
- Wait for delete confirmation message before continuing to delete
- Remove reference to Selenium::WebDriver::Error::StaleElementReferenceError which is not loaded

```
  1) auto reloads WiceGrid should filter by Added
     Failure/Error: rescue Capybara::ElementNotFound, Selenium::WebDriver::Error::StaleElementReferenceError
     
     NameError:
       uninitialized constant Selenium
     # ./spec/features/saved_queries_request_spec.rb:13:in `rescue in delete_all_saved_queries'
     # ./spec/features/saved_queries_request_spec.rb:9:in `delete_all_saved_queries'
     # ./spec/features/saved_queries_request_spec.rb:68:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Capybara::Poltergeist::BrowserError:
     #   There was an error inside the PhantomJS portion of Poltergeist. If this is the error returned, and not the cause of a more detailed error response, this is probably a bug, so please report it. 
     #   
     #   Poltergeist.ObsoleteNode: 
     #   /Users/jasonbarnabe/.rvm/gems/ruby-2.4.4/gems/poltergeist-1.9.0/lib/capybara/poltergeist/browser.rb:351:in `command'
```