### PR TITLE
Convert specs to RSpec 3.6.0 syntax with Transpec

### DIFF
--- a/gemfiles/rails_5.0.gemfile.lock
+++ b/gemfiles/rails_5.0.gemfile.lock
@@ -122,6 +122,7 @@ GEM
       activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    libv8 (3.16.14.19)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -180,6 +181,7 @@ GEM
       ffi (>= 0.5.0, < 2)
     rdoc (4.2.2)
       json (~> 1.4)
+    ref (2.0.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)
@@ -237,6 +239,9 @@ GEM
     temple (0.8.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -284,6 +289,7 @@ DEPENDENCIES
   shoulda-matchers (= 2.8.0)
   simplecov (~> 0.7)
   sqlite3 (~> 1.3)
+  therubyracer
   turbolinks (~> 5.1.1)
   wice_grid!
   yard (~> 0.8)

--- a/gemfiles/rails_5.1.gemfile.lock
+++ b/gemfiles/rails_5.1.gemfile.lock
@@ -122,6 +122,7 @@ GEM
       activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    libv8 (3.16.14.19)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -180,6 +181,7 @@ GEM
       ffi (>= 0.5.0, < 2)
     rdoc (4.2.2)
       json (~> 1.4)
+    ref (2.0.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)
@@ -237,6 +239,9 @@ GEM
     temple (0.8.0)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -284,6 +289,7 @@ DEPENDENCIES
   shoulda-matchers (= 2.8.0)
   simplecov (~> 0.7)
   sqlite3 (~> 1.3)
+  therubyracer
   turbolinks (~> 5.1.1)
   wice_grid!
   yard (~> 0.8)

--- a/spec/features/action_column_request_spec.rb
+++ b/spec/features/action_column_request_spec.rb
@@ -13,7 +13,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should have_content('Selected tasks: 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, and 520')
+    expect(page).to have_content('Selected tasks: 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, and 520')
   end
 
   it 'should select rows with the select all button and deselect them with the deselect button' do
@@ -21,13 +21,13 @@ describe 'action_column WiceGrid', type: :request, js: true do
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should have_content('Selected tasks: 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, and 526')
+    expect(page).to have_content('Selected tasks: 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, and 526')
 
     find(:css, '.clickable.deselect-all').click
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should have_no_content('Selected tasks: 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, and 526')
+    expect(page).to have_no_content('Selected tasks: 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, and 526')
   end
 
   it 'should filter by ID inside a form, two limits' do
@@ -37,15 +37,15 @@ describe 'action_column WiceGrid', type: :request, js: true do
     first(:css, 'button.btn', text: 'Process tasks').click
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('507')
+      expect(page).to have_content('507')
     end
 
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
@@ -53,15 +53,15 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted.active-filter' do
-      page.should have_content('509')
+      expect(page).to have_content('509')
     end
 
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
@@ -69,11 +69,11 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('507')
+      expect(page).to have_content('507')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -81,7 +81,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
   end
 
@@ -90,22 +90,22 @@ describe 'action_column WiceGrid', type: :request, js: true do
     first(:css, 'button.btn', text: 'Process tasks').click
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('Yes')
+      expect(page).to have_content('Yes')
     end
 
     select 'no', from: 'g_f_archived'
     first(:css, 'button.btn', text: 'Process tasks').click
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 46')
+      expect(page).to have_content('1-20 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     within 'ul.pagination' do
@@ -113,11 +113,11 @@ describe 'action_column WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('21-40 / 46')
+      expect(page).to have_content('21-40 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
   end
 
@@ -129,12 +129,12 @@ describe 'action_column WiceGrid', type: :request, js: true do
     first(:css, 'button.btn', text: 'Process tasks').click
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 29')
+      expect(page).to have_content('1-20 / 29')
     end
 
     # sleep 200
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2011-09-13 22:11:12')
+      expect(page).to have_content('2011-09-13 22:11:12')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -143,7 +143,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 29')
+      expect(page).to have_content('1-20 / 29')
     end
 
     within 'ul.pagination' do
@@ -153,7 +153,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
       # page.should have_content('2011-08-14 22:11:12')
-      page.should have_content('2011-09-22 22:11:12')
+      expect(page).to have_content('2011-09-22 22:11:12')
     end
   end
 
@@ -165,11 +165,11 @@ describe 'action_column WiceGrid', type: :request, js: true do
     first(:css, 'button.btn', text: 'Process tasks').click
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2012-07-29')
+      expect(page).to have_content('2012-07-29')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -178,7 +178,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     within 'ul.pagination' do
@@ -187,7 +187,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1 # !!!!
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2012-07-02')
+      expect(page).to have_content('2012-07-02')
     end
 
     set_datepicker(self, 'g_f_due_date_fr_date_placeholder', 2012, 6, 28)
@@ -197,7 +197,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     first(:css, 'button.btn', text: 'Process tasks').click
 
     within '.pagination_status' do
-      page.should have_content('1-1 / 1')
+      expect(page).to have_content('1-1 / 1')
     end
 
     find(:css, '#g_f_due_date_fr_date_view').click
@@ -205,7 +205,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     first(:css, 'button.btn', text: 'Process tasks').click
 
     within '.pagination_status' do
-      page.should have_content('1-10 / 10')
+      expect(page).to have_content('1-10 / 10')
     end
 
     find(:css, '#g_f_due_date_to_date_view').click
@@ -213,7 +213,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     first(:css, 'button.btn', text: 'Process tasks').click
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -223,13 +223,13 @@ describe 'action_column WiceGrid', type: :request, js: true do
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     find(:css, '#g_f_title_n').click
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should have_no_content('sed impedit iste')
+    expect(page).to have_no_content('sed impedit iste')
   end
 
   it 'should reload the title filter' do
@@ -238,38 +238,38 @@ describe 'action_column WiceGrid', type: :request, js: true do
     first(:css, 'button.btn', text: 'Process tasks').click
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('sed impedit iste')
+      expect(page).to have_content('sed impedit iste')
     end
 
-    page.should have_content('corporis expedita vel')
+    expect(page).to have_content('corporis expedita vel')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Title'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('corporis expedita vel')
+      expect(page).to have_content('corporis expedita vel')
     end
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
-    page.should have_content('corporis expedita vel')
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('corporis expedita vel')
+    expect(page).to have_content('sed impedit iste')
   end
 end

--- a/spec/features/adding_rows_request_spec.rb
+++ b/spec/features/adding_rows_request_spec.rb
@@ -12,10 +12,10 @@ describe 'adding rows WiceGrid', type: :request, js: true do
     find(:css, '#grid_submit_grid_icon').click
 
     ['inventore architecto aut', 'veniam tempora', 'doloremque', 'qui animi', 'dolor et corporis'].each do |title|
-      page.should have_content(title)
-      page.should have_content("Panic! \"#{title}\"")
+      expect(page).to have_content(title)
+      expect(page).to have_content("Panic! \"#{title}\"")
     end
 
-    page.should have_content("Don't panic")
+    expect(page).to have_content("Don't panic")
   end
 end

--- a/spec/features/all_records_request_spec.rb
+++ b/spec/features/all_records_request_spec.rb
@@ -8,11 +8,11 @@ describe 'all records WiceGrid', type: :request, js: true do
 
   it 'should filter by custom filters' do
     within 'div.wice-grid-container table.wice-grid tbody' do
-      page.should have_no_content('show all')
+      expect(page).to have_no_content('show all')
     end
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end

--- a/spec/features/auto_reloads2_request_spec.rb
+++ b/spec/features/auto_reloads2_request_spec.rb
@@ -10,7 +10,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     select 'Assigned', from: 'grid_f_status_id'
 
     within '#grid .pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
   end
 
@@ -18,7 +18,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     select 'Divine Firmware', from: 'grid_f_project_id'
 
     within '#grid .pagination_status' do
-      page.should have_content('1-15 / 15')
+      expect(page).to have_content('1-15 / 15')
     end
   end
 
@@ -30,11 +30,11 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 29')
+      expect(page).to have_content('1-20 / 29')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2011-09-13 22:11:12')
+      expect(page).to have_content('2011-09-13 22:11:12')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -43,7 +43,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 29')
+      expect(page).to have_content('1-20 / 29')
     end
 
     within 'ul.pagination' do
@@ -52,13 +52,13 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2011-09-22 22:11:12')
+      expect(page).to have_content('2011-09-22 22:11:12')
       # page.should have_content('2011-08-14 22:11:12')
     end
 
     find(:css, '.wg-external-reset-button').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -67,22 +67,22 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     # find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('Yes')
+      expect(page).to have_content('Yes')
     end
 
     select 'no', from: 'grid_f_archived'
     # find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 46')
+      expect(page).to have_content('1-20 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     within 'ul.pagination' do
@@ -90,16 +90,16 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('21-40 / 46')
+      expect(page).to have_content('21-40 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     find(:css, '.wg-external-reset-button').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -111,42 +111,42 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
 
     sleep 1
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('507')
+      expect(page).to have_content('507')
     end
 
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted.active-filter' do
-      page.should have_content('509')
+      expect(page).to have_content('509')
     end
 
-    page.should have_content('507')
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('507')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('507')
+      expect(page).to have_content('507')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -154,16 +154,16 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
-    page.should have_content('507')
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('507')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     find(:css, '.wg-external-reset-button').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -173,15 +173,15 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     # find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-7 / 7')
+      expect(page).to have_content('1-7 / 7')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('550')
+      expect(page).to have_content('550')
     end
 
     551.upto(556) do |i|
-      page.should have_content(i)
+      expect(page).to have_content(i)
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -190,15 +190,15 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-7 / 7')
+      expect(page).to have_content('1-7 / 7')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted.active-filter' do
-      page.should have_content('556')
+      expect(page).to have_content('556')
     end
 
     551.upto(556) do |i|
-      page.should have_content(i)
+      expect(page).to have_content(i)
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -206,11 +206,11 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-7 / 7')
+      expect(page).to have_content('1-7 / 7')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('550')
+      expect(page).to have_content('550')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -218,16 +218,16 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-7 / 7')
+      expect(page).to have_content('1-7 / 7')
     end
 
     550.upto(556) do |i|
-      page.should have_content(i)
+      expect(page).to have_content(i)
     end
 
     find(:css, '.wg-external-reset-button').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -239,11 +239,11 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2012-07-29')
+      expect(page).to have_content('2012-07-29')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -252,7 +252,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     within 'ul.pagination' do
@@ -261,7 +261,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2012-07-02')
+      expect(page).to have_content('2012-07-02')
       # page.should have_content('2012-07-15')
     end
 
@@ -272,13 +272,13 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-1 / 1')
+      expect(page).to have_content('1-1 / 1')
     end
 
     find(:css, '#grid_f_due_date_fr_date_view').click
 
     within '.pagination_status' do
-      page.should have_content('1-10 / 10')
+      expect(page).to have_content('1-10 / 10')
     end
 
     find(:css, '#grid_f_due_date_to_date_view').click
@@ -286,7 +286,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     # find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -294,54 +294,54 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     fill_in('grid_f_title_v', with: 'sed')
     select 'no', from: 'grid_f_archived'
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     find(:css, '#grid_f_title_n').click
 
-    page.should have_no_content('sed impedit iste')
+    expect(page).to have_no_content('sed impedit iste')
   end
 
   it 'should reload the title filter' do
     fill_in('grid_f_title_v', with: 'ed')
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('sed impedit iste')
+      expect(page).to have_content('sed impedit iste')
     end
 
-    page.should have_content('corporis expedita vel')
+    expect(page).to have_content('corporis expedita vel')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Title'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('corporis expedita vel')
+      expect(page).to have_content('corporis expedita vel')
     end
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
-    page.should have_content('corporis expedita vel')
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('corporis expedita vel')
+    expect(page).to have_content('sed impedit iste')
 
     find(:css, '.wg-external-reset-button').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end

--- a/spec/features/auto_reloads3_request_spec.rb
+++ b/spec/features/auto_reloads3_request_spec.rb
@@ -79,11 +79,11 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     set_datepicker(self, 'grid_f_due_date_to_date_placeholder', 2013, 0, 1)
 
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     within 'div#grid2.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
     set_datepicker(self, 'grid2_f_due_date_fr_date_placeholder', 2012, 0, 1)
@@ -95,30 +95,30 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     within 'div#grid2.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     find(:css, '.grid1 .wg-external-reset-button').click
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
     within 'div#grid2.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     find(:css, '.grid2 .wg-external-reset-button').click
 
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
     within 'div#grid2.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end

--- a/spec/features/auto_reloads_request_spec.rb
+++ b/spec/features/auto_reloads_request_spec.rb
@@ -10,7 +10,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     select 'Assigned', from: 'grid_f_status_id'
 
     within '#grid .pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
   end
 
@@ -18,7 +18,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     select 'Divine Firmware', from: 'grid_f_project_id'
 
     within '#grid .pagination_status' do
-      page.should have_content('1-15 / 15')
+      expect(page).to have_content('1-15 / 15')
     end
   end
 
@@ -32,11 +32,11 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     # find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 29')
+      expect(page).to have_content('1-20 / 29')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2011-09-13 22:11:12')
+      expect(page).to have_content('2011-09-13 22:11:12')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -45,7 +45,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 29')
+      expect(page).to have_content('1-20 / 29')
     end
 
     within 'ul.pagination' do
@@ -55,13 +55,13 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
 
     # WTF
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2011-09-22 22:11:12')
+      expect(page).to have_content('2011-09-22 22:11:12')
     end
 
     find(:css, '#grid_reset_grid_icon').click
     sleep 1
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -70,22 +70,22 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     # find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('Yes')
+      expect(page).to have_content('Yes')
     end
 
     select 'no', from: 'grid_f_archived'
     # find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 46')
+      expect(page).to have_content('1-20 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     within 'ul.pagination' do
@@ -93,16 +93,16 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('21-40 / 46')
+      expect(page).to have_content('21-40 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -111,15 +111,15 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     fill_in('grid_f_id_to', with: 509)
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('507')
+      expect(page).to have_content('507')
     end
 
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     # ID !!!!
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -127,15 +127,15 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted.active-filter' do
-      page.should have_content('509')
+      expect(page).to have_content('509')
     end
 
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     # ID !!!!
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -143,12 +143,12 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     # sleep 10
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('507')
+      expect(page).to have_content('507')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -156,16 +156,16 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
-    page.should have_content('507')
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('507')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -173,15 +173,15 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     fill_in('grid_f_id_fr', with: 550)
 
     within '.pagination_status' do
-      page.should have_content('1-7 / 7')
+      expect(page).to have_content('1-7 / 7')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('550')
+      expect(page).to have_content('550')
     end
 
     551.upto(556) do |i|
-      page.should have_content(i)
+      expect(page).to have_content(i)
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -189,15 +189,15 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-7 / 7')
+      expect(page).to have_content('1-7 / 7')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted.active-filter' do
-      page.should have_content('556')
+      expect(page).to have_content('556')
     end
 
     551.upto(556) do |i|
-      page.should have_content(i)
+      expect(page).to have_content(i)
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -205,11 +205,11 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-7 / 7')
+      expect(page).to have_content('1-7 / 7')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('550')
+      expect(page).to have_content('550')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -217,16 +217,16 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-7 / 7')
+      expect(page).to have_content('1-7 / 7')
     end
 
     550.upto(556) do |i|
-      page.should have_content(i)
+      expect(page).to have_content(i)
     end
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -240,11 +240,11 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2012-07-29')
+      expect(page).to have_content('2012-07-29')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -254,7 +254,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     within 'ul.pagination' do
@@ -264,7 +264,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2012-07-02')
+      expect(page).to have_content('2012-07-02')
     end
 
     set_datepicker(self, 'grid_f_due_date_fr_date_placeholder', 2012, 6, 28)
@@ -274,7 +274,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-1 / 1')
+      expect(page).to have_content('1-1 / 1')
     end
 
     find(:css, '#grid_f_due_date_fr_date_view').click
@@ -282,7 +282,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-10 / 10')
+      expect(page).to have_content('1-10 / 10')
     end
 
     find(:css, '#grid_f_due_date_to_date_view').click
@@ -290,7 +290,7 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -298,54 +298,54 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
     fill_in('grid_f_title_v', with: 'sed')
     select 'no', from: 'grid_f_archived'
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     find(:css, '#grid_f_title_n').click
 
-    page.should have_no_content('sed impedit iste')
+    expect(page).to have_no_content('sed impedit iste')
   end
 
   it 'should reload the title filter' do
     fill_in('grid_f_title_v', with: 'ed')
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('sed impedit iste')
+      expect(page).to have_content('sed impedit iste')
     end
 
-    page.should have_content('corporis expedita vel')
+    expect(page).to have_content('corporis expedita vel')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Title'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('corporis expedita vel')
+      expect(page).to have_content('corporis expedita vel')
     end
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
-    page.should have_content('corporis expedita vel')
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('corporis expedita vel')
+    expect(page).to have_content('sed impedit iste')
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end

--- a/spec/features/basics4_request_spec.rb
+++ b/spec/features/basics4_request_spec.rb
@@ -7,13 +7,13 @@ describe 'basisc4 WiceGrid',  js: true do
   end
 
   it 'should not have disabled filters' do
-    page.should have_no_selector('#grid_f_id_fr')
-    page.should have_no_selector('#grid_f_id_to')
-    page.should have_no_selector('#grid_f_description')
-    page.should have_no_selector('#grid_f_created_at_fr_year')
-    page.should have_no_selector('#grid_f_created_at_fr_month')
+    expect(page).to have_no_selector('#grid_f_id_fr')
+    expect(page).to have_no_selector('#grid_f_id_to')
+    expect(page).to have_no_selector('#grid_f_description')
+    expect(page).to have_no_selector('#grid_f_created_at_fr_year')
+    expect(page).to have_no_selector('#grid_f_created_at_fr_month')
 
-    page.should have_no_selector('#grid_f_created_at_to_year')
-    page.should have_no_selector('#grid_f_created_at_to_month')
+    expect(page).to have_no_selector('#grid_f_created_at_to_year')
+    expect(page).to have_no_selector('#grid_f_created_at_to_month')
   end
 end

--- a/spec/features/basics5_request_spec.rb
+++ b/spec/features/basics5_request_spec.rb
@@ -7,7 +7,7 @@ describe 'basisc5 WiceGrid',  js: true do
   end
 
   it 'should not be able to order columns with disabled ordering' do
-    -> { click_link 'Description' }.should raise_error(Capybara::ElementNotFound)
-    -> { click_link 'Archived' }.should raise_error(Capybara::ElementNotFound)
+    expect { click_link 'Description' }.to raise_error(Capybara::ElementNotFound)
+    expect { click_link 'Archived' }.to raise_error(Capybara::ElementNotFound)
   end
 end

--- a/spec/features/basics6_request_spec.rb
+++ b/spec/features/basics6_request_spec.rb
@@ -8,7 +8,7 @@ describe 'basisc5 WiceGrid',  js: true do
 
   it 'should ordered by Title' do
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Title')
+      expect(page).to have_content('Title')
     end
   end
 
@@ -16,7 +16,7 @@ describe 'basisc5 WiceGrid',  js: true do
     click_on 'show all'
 
     within 'div.wice-grid-container table.wice-grid tbody' do
-      page.should have_no_content('Yes')
+      expect(page).to have_no_content('Yes')
     end
   end
 end

--- a/spec/features/buttons_request_spec.rb
+++ b/spec/features/buttons_request_spec.rb
@@ -11,22 +11,22 @@ describe 'buttons WiceGrid', type: :request, js: true do
     click_button('Submit')
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('Yes')
+      expect(page).to have_content('Yes')
     end
 
     select 'no', from: 'grid_f_archived'
     click_button('Submit')
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 46')
+      expect(page).to have_content('1-20 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     within 'ul.pagination' do
@@ -34,16 +34,16 @@ describe 'buttons WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('21-40 / 46')
+      expect(page).to have_content('21-40 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     click_button('Reset')
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -53,43 +53,43 @@ describe 'buttons WiceGrid', type: :request, js: true do
     click_button('Submit')
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('sed impedit iste')
+      expect(page).to have_content('sed impedit iste')
     end
 
-    page.should have_content('corporis expedita vel')
+    expect(page).to have_content('corporis expedita vel')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Title'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('corporis expedita vel')
+      expect(page).to have_content('corporis expedita vel')
     end
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
-    page.should have_content('corporis expedita vel')
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('corporis expedita vel')
+    expect(page).to have_content('sed impedit iste')
 
     click_button('Reset')
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -99,43 +99,43 @@ describe 'buttons WiceGrid', type: :request, js: true do
     click_button('Submit')
 
     within '.pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+      expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
     end
 
-    page.should have_content('Vero sit voluptate sed tempora et provident sequi nihil.')
+    expect(page).to have_content('Vero sit voluptate sed tempora et provident sequi nihil.')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Description'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
+      expect(page).to have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
     end
 
-    page.should have_content('Adipisci voluptate sed esse velit.')
+    expect(page).to have_content('Adipisci voluptate sed esse velit.')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
-    page.should have_content('Adipisci voluptate sed esse velit.')
-    page.should have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
+    expect(page).to have_content('Adipisci voluptate sed esse velit.')
+    expect(page).to have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
 
     click_button('Reset')
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -147,26 +147,26 @@ describe 'buttons WiceGrid', type: :request, js: true do
     click_button('Submit')
 
     within '.pagination_status' do
-      page.should have_content('1-11 / 11')
+      expect(page).to have_content('1-11 / 11')
     end
 
-    page.should have_content('Inventore iure eos labore ipsum.')
-    page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+    expect(page).to have_content('Inventore iure eos labore ipsum.')
+    expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Description'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-11 / 11')
+      expect(page).to have_content('1-11 / 11')
     end
 
-    page.should have_content('Inventore iure eos labore ipsum.')
-    page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+    expect(page).to have_content('Inventore iure eos labore ipsum.')
+    expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
 
     click_button('Reset')
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end

--- a/spec/features/custom_filter_params_request_spec.rb
+++ b/spec/features/custom_filter_params_request_spec.rb
@@ -9,21 +9,21 @@ describe 'custom_filter_params WiceGrid', type: :request, js: true do
   it 'should lead to a grid with the project custom filter activated to Ultimate Website' do
     click_on 'Ultimate Website'
     within '.pagination_status' do
-      page.should have_content('1-18 / 18')
+      expect(page).to have_content('1-18 / 18')
     end
   end
 
   it 'should lead to a grid with the project custom filter activated to Super Game' do
     click_on 'Super Game'
     within '.pagination_status' do
-      page.should have_content('1-17 / 17')
+      expect(page).to have_content('1-17 / 17')
     end
   end
 
   it 'should lead to a grid with the project custom filter activated to Divine Firmware' do
     click_on 'Divine Firmware'
     within '.pagination_status' do
-      page.should have_content('1-15 / 15')
+      expect(page).to have_content('1-15 / 15')
     end
   end
 end

--- a/spec/features/custom_filters1_request_spec.rb
+++ b/spec/features/custom_filters1_request_spec.rb
@@ -8,27 +8,27 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
 
   it 'should have all options' do
     within '#g1_f_status' do
-      page.should have_content('Development')
-      page.should have_content('Testing')
-      page.should have_content('Production')
+      expect(page).to have_content('Development')
+      expect(page).to have_content('Testing')
+      expect(page).to have_content('Production')
     end
 
     within '#g2_f_status' do
-      page.should have_content('Development')
-      page.should have_content('Testing')
-      page.should have_content('Production')
+      expect(page).to have_content('Development')
+      expect(page).to have_content('Testing')
+      expect(page).to have_content('Production')
     end
 
     within '#g3_f_status' do
-      page.should have_content('development')
-      page.should have_content('testing')
-      page.should have_content('production')
+      expect(page).to have_content('development')
+      expect(page).to have_content('testing')
+      expect(page).to have_content('production')
     end
 
     within '#g4_f_status' do
-      page.should have_content('development')
-      page.should have_content('testing')
-      page.should have_content('production')
+      expect(page).to have_content('development')
+      expect(page).to have_content('testing')
+      expect(page).to have_content('production')
     end
   end
 
@@ -53,25 +53,25 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
   it 'should filter by custom filter' do
     select 'Development', from: 'g1_f_status'
     find(:css, '#g1_submit_grid_icon').click
-    page.should have_selector('#g1 .pagination_status', text: '1-3 / 3')
+    expect(page).to have_selector('#g1 .pagination_status', text: '1-3 / 3')
 
     select 'Development', from: 'g2_f_status'
     find(:css, '#g2_submit_grid_icon').click
-    page.should have_selector('#g1 .pagination_status', text: '1-3 / 3')
-    page.should have_selector('#g2 .pagination_status', text: '1-3 / 3')
+    expect(page).to have_selector('#g1 .pagination_status', text: '1-3 / 3')
+    expect(page).to have_selector('#g2 .pagination_status', text: '1-3 / 3')
 
     select 'development', from: 'g3_f_status'
     find(:css, '#g3_submit_grid_icon').click
-    page.should have_selector('#g1 .pagination_status', text: '1-3 / 3')
-    page.should have_selector('#g2 .pagination_status', text: '1-3 / 3')
-    page.should have_selector('#g3 .pagination_status', text: '1-3 / 3')
+    expect(page).to have_selector('#g1 .pagination_status', text: '1-3 / 3')
+    expect(page).to have_selector('#g2 .pagination_status', text: '1-3 / 3')
+    expect(page).to have_selector('#g3 .pagination_status', text: '1-3 / 3')
 
     select 'development', from: 'g4_f_status'
     find(:css, '#g4_submit_grid_icon').click
-    page.should have_selector('#g1 .pagination_status', text: '1-3 / 3')
-    page.should have_selector('#g2 .pagination_status', text: '1-3 / 3')
-    page.should have_selector('#g3 .pagination_status', text: '1-3 / 3')
-    page.should have_selector('#g4 .pagination_status', text: '1-3 / 3')
+    expect(page).to have_selector('#g1 .pagination_status', text: '1-3 / 3')
+    expect(page).to have_selector('#g2 .pagination_status', text: '1-3 / 3')
+    expect(page).to have_selector('#g3 .pagination_status', text: '1-3 / 3')
+    expect(page).to have_selector('#g4 .pagination_status', text: '1-3 / 3')
   end
 
   it 'should filter by custom filter with multiselect' do
@@ -83,7 +83,7 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
     find(:css, '#g1_submit_grid_icon').click
 
     within '#g1 .pagination_status' do
-      page.should have_content('1-5 / 8')
+      expect(page).to have_content('1-5 / 8')
     end
 
     ###
@@ -95,7 +95,7 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
     find(:css, '#g2_submit_grid_icon').click
 
     within '#g2 .pagination_status' do
-      page.should have_content('1-5 / 8')
+      expect(page).to have_content('1-5 / 8')
     end
 
     ###
@@ -107,7 +107,7 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
     find(:css, '#g3_submit_grid_icon').click
 
     within '#g3 .pagination_status' do
-      page.should have_content('1-5 / 8')
+      expect(page).to have_content('1-5 / 8')
     end
 
     ###
@@ -119,7 +119,7 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
     find(:css, '#g4_submit_grid_icon').click
 
     within '#g4 .pagination_status' do
-      page.should have_content('1-5 / 8')
+      expect(page).to have_content('1-5 / 8')
     end
 
     ##
@@ -128,28 +128,28 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
     select 'Testing', from: 'g1_f_status'
     find(:css, '#g1_submit_grid_icon').click
     within '#g1 .pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     find(:css, '#g2 .collapse-multi-select-icon').click
     select 'Testing', from: 'g2_f_status'
     find(:css, '#g2_submit_grid_icon').click
     within '#g2 .pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     find(:css, '#g3 .collapse-multi-select-icon').click
     select 'testing', from: 'g3_f_status'
     find(:css, '#g3_submit_grid_icon').click
     within '#g3 .pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     find(:css, '#g4 .collapse-multi-select-icon').click
     select 'testing', from: 'g4_f_status'
     find(:css, '#g4_submit_grid_icon').click
     within '#g4 .pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
   end
 end

--- a/spec/features/custom_filters2_request_spec.rb
+++ b/spec/features/custom_filters2_request_spec.rb
@@ -8,29 +8,29 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
 
   it 'should have all options' do
     within '#grid_f_priorities_name' do
-      page.should have_content('Anecdotic')
-      page.should have_content('High')
-      page.should have_content('Low')
-      page.should have_content('Normal')
-      page.should have_content('Urgent')
+      expect(page).to have_content('Anecdotic')
+      expect(page).to have_content('High')
+      expect(page).to have_content('Low')
+      expect(page).to have_content('Normal')
+      expect(page).to have_content('Urgent')
     end
 
     within '#grid_f_status_id' do
-      page.should have_content('Assigned')
-      page.should have_content('Cancelled')
-      page.should have_content('Closed')
-      page.should have_content('Duplicate')
-      page.should have_content('New')
-      page.should have_content('Postponed')
-      page.should have_content('Resolved')
-      page.should have_content('Started')
-      page.should have_content('Verified')
+      expect(page).to have_content('Assigned')
+      expect(page).to have_content('Cancelled')
+      expect(page).to have_content('Closed')
+      expect(page).to have_content('Duplicate')
+      expect(page).to have_content('New')
+      expect(page).to have_content('Postponed')
+      expect(page).to have_content('Resolved')
+      expect(page).to have_content('Started')
+      expect(page).to have_content('Verified')
     end
 
     within '#grid_f_project_id' do
-      page.should have_content('Divine Firmware')
-      page.should have_content('Super Game')
-      page.should have_content('Ultimate Website')
+      expect(page).to have_content('Divine Firmware')
+      expect(page).to have_content('Super Game')
+      expect(page).to have_content('Ultimate Website')
     end
   end
 
@@ -47,7 +47,7 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
   end
 end

--- a/spec/features/custom_filters3_request_spec.rb
+++ b/spec/features/custom_filters3_request_spec.rb
@@ -8,22 +8,22 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
 
   it 'should have all options' do
     within '#grid_f_expected_version_id' do
-      page.should have_content('1.0')
-      page.should have_content('2.0')
-      page.should have_content('1.2')
+      expect(page).to have_content('1.0')
+      expect(page).to have_content('2.0')
+      expect(page).to have_content('1.2')
     end
 
     within '#grid_f_versions_name' do
-      page.should have_content('1.0')
-      page.should have_content('1.1')
-      page.should have_content('1.2')
-      page.should have_content('2.0')
-      page.should have_content('3.0')
-      page.should have_content('6.0')
-      page.should have_content('7.1')
-      page.should have_content('8.0')
-      page.should have_content('88.1')
-      page.should have_content('99.0')
+      expect(page).to have_content('1.0')
+      expect(page).to have_content('1.1')
+      expect(page).to have_content('1.2')
+      expect(page).to have_content('2.0')
+      expect(page).to have_content('3.0')
+      expect(page).to have_content('6.0')
+      expect(page).to have_content('7.1')
+      expect(page).to have_content('8.0')
+      expect(page).to have_content('88.1')
+      expect(page).to have_content('99.0')
     end
   end
 
@@ -36,7 +36,7 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-5 / 5')
+      expect(page).to have_content('1-5 / 5')
     end
 
     select '1.0', from: 'grid_f_expected_version_id'
@@ -44,7 +44,7 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
   end
 end

--- a/spec/features/custom_ordering_request_spec.rb
+++ b/spec/features/custom_ordering_request_spec.rb
@@ -8,7 +8,7 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
 
   it 'should be sorted by the length of the word' do
     within 'div#grid.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('New')
+      expect(page).to have_content('New')
     end
 
     within 'div#grid.wice-grid-container table.wice-grid thead' do
@@ -16,13 +16,13 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
     end
 
     within 'div#grid.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('Duplicate')
+      expect(page).to have_content('Duplicate')
     end
   end
 
   it 'should be sorted by the position of the status' do
     within 'div#g2.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('New')
+      expect(page).to have_content('New')
     end
 
     within 'div#g2.wice-grid-container table.wice-grid thead' do
@@ -30,7 +30,7 @@ describe 'custom_ordering WiceGrid', type: :request, js: true do
     end
 
     within 'div#g2.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('Verified')
+      expect(page).to have_content('Verified')
     end
   end
 end

--- a/spec/features/dates_request_spec.rb
+++ b/spec/features/dates_request_spec.rb
@@ -42,7 +42,7 @@ describe 'dates WiceGrid', type: :request, js: true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     fill_in('grid_f_title', with: 'at')
@@ -50,7 +50,7 @@ describe 'dates WiceGrid', type: :request, js: true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-1 / 1')
+      expect(page).to have_content('1-1 / 1')
     end
   end
 end

--- a/spec/features/detached_filters_two_grids_spec.rb
+++ b/spec/features/detached_filters_two_grids_spec.rb
@@ -12,7 +12,7 @@ describe 'buttons WiceGrid', type: :request, js: true do
     find(:css, '.external-buttons-grid1 .wg-external-submit-button').click
 
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     select 'no', from: 'grid2_f_archived'
@@ -20,11 +20,11 @@ describe 'buttons WiceGrid', type: :request, js: true do
 
     # stays the same
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     within 'div#grid2.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 46')
+      expect(page).to have_content('1-20 / 46')
     end
 
     set_datepicker(self, 'grid_f_due_date_fr_date_placeholder', 2012, 11, 1)
@@ -32,7 +32,7 @@ describe 'buttons WiceGrid', type: :request, js: true do
     find(:css, '.external-buttons-grid1 .wg-external-submit-button').click
 
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     set_datepicker(self, 'grid2_f_due_date_fr_date_placeholder', 2013, 0, 1)
@@ -41,31 +41,31 @@ describe 'buttons WiceGrid', type: :request, js: true do
 
     # stays the same
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div#grid2.wice-grid-container .pagination_status' do
-      page.should have_content('1-15 / 15')
+      expect(page).to have_content('1-15 / 15')
     end
 
     find(:css, '.external-buttons-grid1 .wg-external-reset-button').click
 
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
     within 'div#grid2.wice-grid-container .pagination_status' do
-      page.should have_content('1-15 / 15')
+      expect(page).to have_content('1-15 / 15')
     end
 
     find(:css, '.external-buttons-grid2 .wg-external-reset-button').click
 
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
     within 'div#grid2.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
     fill_in('grid_f_title', with: 'ed')
@@ -73,15 +73,15 @@ describe 'buttons WiceGrid', type: :request, js: true do
     find(:css, '.external-buttons-grid1 .wg-external-submit-button').click
 
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div#grid2.wice-grid-container .pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
     within 'div#grid.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('sed impedit iste')
+      expect(page).to have_content('sed impedit iste')
     end
 
     fill_in('grid2_f_title', with: 'qui')
@@ -89,19 +89,19 @@ describe 'buttons WiceGrid', type: :request, js: true do
     find(:css, '.external-buttons-grid2 .wg-external-submit-button').click
 
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div#grid2.wice-grid-container .pagination_status' do
-      page.should have_content('1-5 / 5')
+      expect(page).to have_content('1-5 / 5')
     end
 
     within 'div#grid.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('sed impedit iste')
+      expect(page).to have_content('sed impedit iste')
     end
 
     within 'div#grid2.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('sequi')
+      expect(page).to have_content('sequi')
     end
 
     fill_in('grid2_f_description', with: 'in')
@@ -109,19 +109,19 @@ describe 'buttons WiceGrid', type: :request, js: true do
     find(:css, '.external-buttons-grid2 .wg-external-submit-button').click
 
     within 'div#grid.wice-grid-container .pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div#grid2.wice-grid-container .pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div#grid.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('sed impedit iste')
+      expect(page).to have_content('sed impedit iste')
     end
 
     within first(:css, 'div#grid2.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter') do
-      page.should have_content('sequi')
+      expect(page).to have_content('sequi')
     end
   end
 end

--- a/spec/features/disable_all_filters_spec.rb
+++ b/spec/features/disable_all_filters_spec.rb
@@ -7,16 +7,16 @@ describe 'disable_all_filters WiceGrid', type: :request, js: true do
   end
 
   it 'should not have disabled filters' do
-    page.should have_no_selector('#grid_f_id_fr')
-    page.should have_no_selector('#grid_f_id_to')
-    page.should have_no_selector('#grid_f_description')
-    page.should have_no_selector('#grid_f_created_at_fr_year')
-    page.should have_no_selector('#grid_f_created_at_fr_month')
+    expect(page).to have_no_selector('#grid_f_id_fr')
+    expect(page).to have_no_selector('#grid_f_id_to')
+    expect(page).to have_no_selector('#grid_f_description')
+    expect(page).to have_no_selector('#grid_f_created_at_fr_year')
+    expect(page).to have_no_selector('#grid_f_created_at_fr_month')
 
-    page.should have_no_selector('#grid_f_created_at_to_year')
-    page.should have_no_selector('#grid_f_created_at_to_month')
+    expect(page).to have_no_selector('#grid_f_created_at_to_year')
+    expect(page).to have_no_selector('#grid_f_created_at_to_month')
 
-    page.should have_no_selector('#grid_f_title')
-    page.should have_no_selector('#grid_f_archived')
+    expect(page).to have_no_selector('#grid_f_title')
+    expect(page).to have_no_selector('#grid_f_archived')
   end
 end

--- a/spec/features/hiding_checkboxes_in_action_column_request_spec.rb
+++ b/spec/features/hiding_checkboxes_in_action_column_request_spec.rb
@@ -14,9 +14,9 @@ describe 'action_column WiceGrid', type: :request, js: true do
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    lambda do
+    expect do
       find(:css, %(.sel input[type=checkbox]))
-    end.should raise_error(Capybara::ElementNotFound)
+    end.to raise_error(Capybara::ElementNotFound)
   end
 
   it 'should select rows' do
@@ -26,7 +26,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should have_content('Selected tasks: 510, 511, 512, 513, 514, 515, 516, 517, 518, and 520')
+    expect(page).to have_content('Selected tasks: 510, 511, 512, 513, 514, 515, 516, 517, 518, and 520')
   end
 
   it 'should select rows with the select all button and deselect them with the deselect button' do
@@ -34,13 +34,13 @@ describe 'action_column WiceGrid', type: :request, js: true do
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should have_content('Selected tasks: 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 520, 521, 522, 523, 524, 525, and 526')
+    expect(page).to have_content('Selected tasks: 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 520, 521, 522, 523, 524, 525, and 526')
 
     find(:css, %(.clickable.deselect-all)).click
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should have_no_content('Selected tasks: 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 520, 521, 522, 523, 524, 525, and 526')
+    expect(page).to have_no_content('Selected tasks: 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 520, 521, 522, 523, 524, 525, and 526')
   end
 
   it 'should keep the state of filter inside a form' do
@@ -54,15 +54,15 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('507')
+      expect(page).to have_content('507')
     end
 
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
@@ -70,15 +70,15 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted.active-filter' do
-      page.should have_content('509')
+      expect(page).to have_content('509')
     end
 
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
@@ -86,11 +86,11 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('507')
+      expect(page).to have_content('507')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -99,7 +99,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
   end
 
@@ -108,22 +108,22 @@ describe 'action_column WiceGrid', type: :request, js: true do
     first(:css, 'button.btn', text: 'Process tasks').click
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('Yes')
+      expect(page).to have_content('Yes')
     end
 
     select 'no', from: 'g_f_archived'
     first(:css, 'button.btn', text: 'Process tasks').click
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 46')
+      expect(page).to have_content('1-20 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     within 'ul.pagination' do
@@ -131,11 +131,11 @@ describe 'action_column WiceGrid', type: :request, js: true do
     end
 
     within '.pagination_status' do
-      page.should have_content('21-40 / 46')
+      expect(page).to have_content('21-40 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
   end
 
@@ -148,11 +148,11 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 29')
+      expect(page).to have_content('1-20 / 29')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2011-09-13 22:11:12')
+      expect(page).to have_content('2011-09-13 22:11:12')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -161,7 +161,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 29')
+      expect(page).to have_content('1-20 / 29')
     end
 
     within 'ul.pagination' do
@@ -170,7 +170,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2011-09-22 22:11:12')
+      expect(page).to have_content('2011-09-22 22:11:12')
       # page.should have_content('2011-08-14 22:11:12')
     end
   end
@@ -184,11 +184,11 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2012-07-29')
+      expect(page).to have_content('2012-07-29')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -197,7 +197,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     within 'ul.pagination' do
@@ -206,7 +206,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2012-07-02')
+      expect(page).to have_content('2012-07-02')
     end
 
     set_datepicker(self, 'g_f_due_date_fr_date_placeholder', 2012, 6, 28)
@@ -217,7 +217,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-1 / 1')
+      expect(page).to have_content('1-1 / 1')
     end
 
     find(:css, '#g_f_due_date_fr_date_view').click
@@ -227,7 +227,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-10 / 10')
+      expect(page).to have_content('1-10 / 10')
     end
 
     find(:css, '#g_f_due_date_to_date_view').click
@@ -237,7 +237,7 @@ describe 'action_column WiceGrid', type: :request, js: true do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -247,13 +247,13 @@ describe 'action_column WiceGrid', type: :request, js: true do
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     find(:css, '#g_f_title_n').click
 
     first(:css, 'button.btn', text: 'Process tasks').click
 
-    page.should have_no_content('sed impedit iste')
+    expect(page).to have_no_content('sed impedit iste')
   end
 
   it 'should reload the title filter' do
@@ -262,38 +262,38 @@ describe 'action_column WiceGrid', type: :request, js: true do
     first(:css, 'button.btn', text: 'Process tasks').click
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('sed impedit iste')
+      expect(page).to have_content('sed impedit iste')
     end
 
-    page.should have_content('corporis expedita vel')
+    expect(page).to have_content('corporis expedita vel')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Title'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('corporis expedita vel')
+      expect(page).to have_content('corporis expedita vel')
     end
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
-    page.should have_content('corporis expedita vel')
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('corporis expedita vel')
+    expect(page).to have_content('sed impedit iste')
   end
 end

--- a/spec/features/integration_with_application_view_request_spec.rb
+++ b/spec/features/integration_with_application_view_request_spec.rb
@@ -7,26 +7,26 @@ describe 'current_page_records & all_pages_records WiceGrid', type: :request, js
   end
 
   it 'should return records displayed on the page and throughout all pages' do
-    page.should have_content('10 records on the current page: 507, 519, 537, 540, 511, 515, 523, 524, 527, and 531')
-    page.should have_content('50 records throughout all pages: 507, 519, 537, 540, 511, 515, 523, 524, 527, 531, 542, 551, 518, 520, 532, 535, 539, 512, 514, 516, 521, 522, 543, 544, 546, 550, 552, 510, 541, 553, 508, 513, 528, 529, 548, 556, 525, 534, 547, 555, 509, 517, 526, 536, 538, 545, 549, 530, 533, and 554')
+    expect(page).to have_content('10 records on the current page: 507, 519, 537, 540, 511, 515, 523, 524, 527, and 531')
+    expect(page).to have_content('50 records throughout all pages: 507, 519, 537, 540, 511, 515, 523, 524, 527, 531, 542, 551, 518, 520, 532, 535, 539, 512, 514, 516, 521, 522, 543, 544, 546, 550, 552, 510, 541, 553, 508, 513, 528, 529, 548, 556, 525, 534, 547, 555, 509, 517, 526, 536, 538, 545, 549, 530, 533, and 554')
 
     fill_in('g_f_title', with: 'ed')
 
-    page.should have_content('2 records throughout all pages: 507 and 534')
-    page.should have_content('2 records on the current page: 507 and 534')
+    expect(page).to have_content('2 records throughout all pages: 507 and 534')
+    expect(page).to have_content('2 records on the current page: 507 and 534')
 
     find(:css, '#g_reset_grid_icon').click
 
     select 'Cancelled',  from: 'g_f_status_id'
 
-    page.should have_content('8 records on the current page: 511, 515, 523, 524, 527, 531, 542, and 551')
-    page.should have_content('8 records throughout all pages: 511, 515, 523, 524, 527, 531, 542, and 551')
+    expect(page).to have_content('8 records on the current page: 511, 515, 523, 524, 527, 531, 542, and 551')
+    expect(page).to have_content('8 records throughout all pages: 511, 515, 523, 524, 527, 531, 542, and 551')
 
     find(:css, '#g_reset_grid_icon').click
 
     select 'no',  from: 'g_f_archived'
 
-    page.should have_content('10 records on the current page: 507, 519, 537, 540, 511, 515, 523, 527, 531, and 542')
-    page.should have_content('46 records throughout all pages: 507, 519, 537, 540, 511, 515, 523, 527, 531, 542, 551, 518, 520, 532, 535, 539, 512, 514, 516, 521, 522, 543, 544, 546, 552, 510, 541, 553, 508, 528, 529, 548, 556, 525, 534, 547, 555, 509, 517, 526, 536, 538, 545, 549, 530, and 554')
+    expect(page).to have_content('10 records on the current page: 507, 519, 537, 540, 511, 515, 523, 527, 531, and 542')
+    expect(page).to have_content('46 records throughout all pages: 507, 519, 537, 540, 511, 515, 523, 527, 531, 542, 551, 518, 520, 532, 535, 539, 512, 514, 516, 521, 522, 543, 544, 546, 552, 510, 541, 553, 508, 528, 529, 548, 556, 525, 534, 547, 555, 509, 517, 526, 536, 538, 545, 549, 530, and 554')
   end
 end

--- a/spec/features/integration_with_forms_request_spec.rb
+++ b/spec/features/integration_with_forms_request_spec.rb
@@ -8,19 +8,19 @@ describe 'dump_filter_parameters_as_hidden_fields WiceGrid', type: :request, js:
 
   it 'should reload the page' do
     within '.pagination_status' do
-      page.should have_content('1-20 / 46')
+      expect(page).to have_content('1-20 / 46')
     end
 
     select 'View archived tasks', from: 'archived'
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     select 'View active tasks', from: 'archived'
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 46')
+      expect(page).to have_content('1-20 / 46')
     end
   end
 
@@ -31,19 +31,19 @@ describe 'dump_filter_parameters_as_hidden_fields WiceGrid', type: :request, js:
     find(:css, '#g_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     select 'View archived tasks', from: 'archived'
 
     within '.pagination_status' do
-      page.should have_content('0')
+      expect(page).to have_content('0')
     end
 
     select 'View active tasks', from: 'archived'
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
   end
 
@@ -53,19 +53,19 @@ describe 'dump_filter_parameters_as_hidden_fields WiceGrid', type: :request, js:
     find(:css, '#g_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     select 'View archived tasks', from: 'archived'
 
     within '.pagination_status' do
-      page.should have_content('0')
+      expect(page).to have_content('0')
     end
 
     select 'View active tasks', from: 'archived'
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
   end
 
@@ -76,19 +76,19 @@ describe 'dump_filter_parameters_as_hidden_fields WiceGrid', type: :request, js:
     find(:css, '#g_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 44')
+      expect(page).to have_content('1-20 / 44')
     end
 
     select 'View archived tasks', from: 'archived'
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     select 'View active tasks', from: 'archived'
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 44')
+      expect(page).to have_content('1-20 / 44')
     end
   end
 
@@ -99,19 +99,19 @@ describe 'dump_filter_parameters_as_hidden_fields WiceGrid', type: :request, js:
     find(:css, '#g_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     select 'View archived tasks', from: 'archived'
 
     within '.pagination_status' do
-      page.should have_content('0')
+      expect(page).to have_content('0')
     end
 
     select 'View active tasks', from: 'archived'
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
   end
 
@@ -123,19 +123,19 @@ describe 'dump_filter_parameters_as_hidden_fields WiceGrid', type: :request, js:
     find(:css, '#g_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-15 / 15')
+      expect(page).to have_content('1-15 / 15')
     end
 
     select 'View archived tasks', from: 'archived'
 
     within '.pagination_status' do
-      page.should have_content('0')
+      expect(page).to have_content('0')
     end
 
     select 'View active tasks', from: 'archived'
 
     within '.pagination_status' do
-      page.should have_content('1-15 / 15')
+      expect(page).to have_content('1-15 / 15')
     end
   end
 end

--- a/spec/features/joining_tables_spec.rb
+++ b/spec/features/joining_tables_spec.rb
@@ -7,10 +7,10 @@ describe 'joining_tables WiceGrid', type: :request, js: true do
   end
 
   it 'should have filters for joined tables' do
-    page.should have_field('grid[f][priorities.name]')
-    page.should have_field('grid[f][statuses.name]')
-    page.should have_field('grid[f][projects.name]')
-    page.should have_field('grid[f][users.name]')
+    expect(page).to have_field('grid[f][priorities.name]')
+    expect(page).to have_field('grid[f][statuses.name]')
+    expect(page).to have_field('grid[f][projects.name]')
+    expect(page).to have_field('grid[f][users.name]')
   end
 
   it 'should have filter joined tables' do
@@ -22,19 +22,19 @@ describe 'joining_tables WiceGrid', type: :request, js: true do
      find(:css, '#grid_submit_grid_icon').click
 
      within '.pagination_status' do
-       page.should have_content('1-1 / 1')
+       expect(page).to have_content('1-1 / 1')
      end
 
      within first(:css, 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter') do
-       page.should have_content('Normal')
+       expect(page).to have_content('Normal')
      end
 
      within first(:css, 'div.wice-grid-container table.wice-grid tbody tr:first-child td') do
-       page.should have_content('508')
+       expect(page).to have_content('508')
      end
 
      within 'div.wice-grid-container table.wice-grid tbody' do
-       page.should have_content('sequi')
+       expect(page).to have_content('sequi')
      end
   end
 end

--- a/spec/features/localization_request_spec.rb
+++ b/spec/features/localization_request_spec.rb
@@ -9,19 +9,19 @@ describe 'localization WiceGrid', type: :request, js: true do
   it 'should switch to different languages' do
     click_on('en')
     sleep 1
-    page.should have_content('show all')
+    expect(page).to have_content('show all')
 
     click_on('nl')
     sleep 1
-    page.should have_content('Alle rijen tonen')
+    expect(page).to have_content('Alle rijen tonen')
 
     click_on('fr')
     sleep 1
-    page.should have_content('Voir tous')
+    expect(page).to have_content('Voir tous')
 
     click_on('is')
     sleep 1
-    page.should have_content('Sýna all')
+    expect(page).to have_content('Sýna all')
 
     click_on('en')
   end

--- a/spec/features/many_grids_on_page_request_spec.rb
+++ b/spec/features/many_grids_on_page_request_spec.rb
@@ -12,7 +12,7 @@ describe 'many_grids_on_page WiceGrid', type: :request, js: true do
     end
 
     within 'div#g1.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('ab')
+      expect(page).to have_content('ab')
     end
 
     within 'div#g2.wice-grid-container table.wice-grid thead' do
@@ -20,19 +20,19 @@ describe 'many_grids_on_page WiceGrid', type: :request, js: true do
     end
 
     within 'div#g1.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('Title')
+      expect(page).to have_content('Title')
     end
 
     within 'div#g2.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('Description')
+      expect(page).to have_content('Description')
     end
 
     within 'div#g1.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('ab')
+      expect(page).to have_content('ab')
     end
 
     within 'div#g2.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('Accusamus voluptas sunt deleniti iusto dolorem repudiandae.')
+      expect(page).to have_content('Accusamus voluptas sunt deleniti iusto dolorem repudiandae.')
     end
   end
 
@@ -41,13 +41,13 @@ describe 'many_grids_on_page WiceGrid', type: :request, js: true do
       click_link '2'
     end
 
-    page.should have_selector('#g1 ul.pagination li.active', text: '2')
+    expect(page).to have_selector('#g1 ul.pagination li.active', text: '2')
 
     within '#g2 ul.pagination' do
       click_link '3'
     end
 
-    page.should have_selector('#g2 ul.pagination li.active', text: '3')
+    expect(page).to have_selector('#g2 ul.pagination li.active', text: '3')
   end
 
   it 'should show all records independantly for the two grids' do
@@ -56,15 +56,15 @@ describe 'many_grids_on_page WiceGrid', type: :request, js: true do
     end
 
     within 'div#g1.wice-grid-container table.wice-grid' do
-      page.should have_selector('a.wg-back-to-pagination-link')
+      expect(page).to have_selector('a.wg-back-to-pagination-link')
     end
 
     within '#g1 .pagination_status' do
-      page.should have_content('1-50 / 50')
+      expect(page).to have_content('1-50 / 50')
     end
 
     within '#g2 .pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -74,11 +74,11 @@ describe 'many_grids_on_page WiceGrid', type: :request, js: true do
     find(:css, '#g1_submit_grid_icon').click
 
     within '#g1 .pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
     within 'div#g1.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+      expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
     end
 
     fill_in('g2_f_description', with: 'voluptas')
@@ -86,19 +86,19 @@ describe 'many_grids_on_page WiceGrid', type: :request, js: true do
     find(:css, '#g2_submit_grid_icon').click
 
     within '#g2 .pagination_status' do
-      page.should have_content('1-1 / 1')
+      expect(page).to have_content('1-1 / 1')
     end
 
     within 'div#g2.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('Accusamus voluptas sunt deleniti iusto dolorem repudiandae.')
+      expect(page).to have_content('Accusamus voluptas sunt deleniti iusto dolorem repudiandae.')
     end
 
     within '#g1 .pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
     within 'div#g1.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+      expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
     end
   end
 end

--- a/spec/features/negation_request_spec.rb
+++ b/spec/features/negation_request_spec.rb
@@ -12,12 +12,12 @@ describe 'negation WiceGrid', type: :request, js: true do
 
     find(:css, '#grid_submit_grid_icon').click
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     find(:css, '#grid_f_title_n').click
 
     find(:css, '#grid_submit_grid_icon').click
 
-    page.should have_no_content('sed impedit iste')
+    expect(page).to have_no_content('sed impedit iste')
   end
 end

--- a/spec/features/no_records_request_spec.rb
+++ b/spec/features/no_records_request_spec.rb
@@ -8,19 +8,19 @@ describe 'no_records WiceGrid', type: :request, js: true do
 
   it 'should contain a No Records block for example 1' do
     within '.example1' do
-      page.should have_content('No records found')
+      expect(page).to have_content('No records found')
     end
   end
 
   it 'should contain a No Records block for example 2' do
     within '.example2' do
-      page.should have_content('No records found')
+      expect(page).to have_content('No records found')
     end
   end
 
   it 'should contain a No Records block for example 3' do
     within '.example3' do
-      page.should have_content('No records found')
+      expect(page).to have_content('No records found')
     end
   end
 end

--- a/spec/features/resultset_processings2_request_spec.rb
+++ b/spec/features/resultset_processings2_request_spec.rb
@@ -8,20 +8,20 @@ describe 'with_resultset WiceGrid', type: :request, js: true do
 
   it 'should show records displayed on all pages' do
     find(:css, '#process').click
-    page.should have_content('50 records on all pages: 507, 519, 537, 540, 511, 515, 523, 524, 527, 531, 542, 551, 518, 520, 532, 535, 539, 512, 514, 516, 521, 522, 543, 544, 546, 550, 552, 510, 541, 553, 508, 513, 528, 529, 548, 556, 525, 534, 547, 555, 509, 517, 526, 536, 538, 545, 549, 530, 533, and 554')
+    expect(page).to have_content('50 records on all pages: 507, 519, 537, 540, 511, 515, 523, 524, 527, 531, 542, 551, 518, 520, 532, 535, 539, 512, 514, 516, 521, 522, 543, 544, 546, 550, 552, 510, 541, 553, 508, 513, 528, 529, 548, 556, 525, 534, 547, 555, 509, 517, 526, 536, 538, 545, 549, 530, 533, and 554')
   end
 
   it 'should show records displayed on all pages with a text filter selection' do
     fill_in('g_f_title', with: 'ed')
     sleep 2
     find(:css, '#process').click
-    page.should have_content('2 records on all pages: 507 and 534')
+    expect(page).to have_content('2 records on all pages: 507 and 534')
   end
 
   it 'should show records displayed on all pages with a custom filter selection' do
     select 'Cancelled',  from: 'g_f_status_id'
     sleep 2
     find(:css, '#process').click
-    page.should have_content('8 records on all pages: 511, 515, 523, 524, 527, 531, 542, and 551')
+    expect(page).to have_content('8 records on all pages: 511, 515, 523, 524, 527, 531, 542, and 551')
   end
 end

--- a/spec/features/resultset_processings_request_spec.rb
+++ b/spec/features/resultset_processings_request_spec.rb
@@ -7,26 +7,26 @@ describe 'with_resultset WiceGrid', type: :request, js: true do
   end
 
   it 'should return records displayed on the page' do
-    page.should have_content('10 records on the current page: 507, 519, 537, 540, 511, 515, 523, 524, 527, and 531')
+    expect(page).to have_content('10 records on the current page: 507, 519, 537, 540, 511, 515, 523, 524, 527, and 531')
 
     fill_in('g_f_title', with: 'ed')
 
     sleep 1
 
-    page.should have_content('2 records on the current page: 507 and 534')
+    expect(page).to have_content('2 records on the current page: 507 and 534')
 
     find(:css, '#g_reset_grid_icon').click
     sleep 1
 
     select 'Cancelled',  from: 'g_f_status_id'
 
-    page.should have_content('8 records on the current page: 511, 515, 523, 524, 527, 531, 542, and 551')
+    expect(page).to have_content('8 records on the current page: 511, 515, 523, 524, 527, 531, 542, and 551')
 
     find(:css, '#g_reset_grid_icon').click
     sleep 1
 
     select 'no',  from: 'g_f_archived'
 
-    page.should have_content('10 records on the current page: 507, 519, 537, 540, 511, 515, 523, 527, 531, and 542')
+    expect(page).to have_content('10 records on the current page: 507, 519, 537, 540, 511, 515, 523, 527, 531, and 542')
   end
 end

--- a/spec/features/saved_queries_request_spec.rb
+++ b/spec/features/saved_queries_request_spec.rb
@@ -18,11 +18,11 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
   it 'should filter by Added' do
     check_saved_query = lambda do
       within '.pagination_status' do
-        page.should have_content('1-20 / 29')
+        expect(page).to have_content('1-20 / 29')
       end
 
       within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-        page.should have_content('2011-08-13 22:11:12')
+        expect(page).to have_content('2011-08-13 22:11:12')
       end
     end
 
@@ -48,36 +48,36 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
 
     sleep 1
 
-    page.should have_content('Query saved.')
-    page.should have_content('test query 1')
+    expect(page).to have_content('Query saved.')
+    expect(page).to have_content('test query 1')
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
-    page.should have_content('test query 1')
+    expect(page).to have_content('test query 1')
 
     find(:css, '.wice-grid-query-load-link[title="Load query test query 1"]').click
 
     check_saved_query.call
 
     within '.wice-grid-container' do
-      page.should have_content('test query 1')
+      expect(page).to have_content('test query 1')
     end
 
     delete_all_saved_queries self
-    page.should have_content('Saved query deleted.')
+    expect(page).to have_content('Saved query deleted.')
   end
 
   it 'should filter by Archived and Project Name' do
     check_saved_query = lambda do
       within '.pagination_status' do
-        page.should have_content('1-2 / 2')
+        expect(page).to have_content('1-2 / 2')
       end
 
       within first(:css, 'td.active-filter') do
-        page.should have_content('Ultimate Website')
+        expect(page).to have_content('Ultimate Website')
       end
     end
 
@@ -95,25 +95,25 @@ describe 'auto reloads WiceGrid', type: :request, js: true do
 
     sleep 1
 
-    page.should have_content('Query saved.')
-    page.should have_content('test query 2')
+    expect(page).to have_content('Query saved.')
+    expect(page).to have_content('test query 2')
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
-    page.should have_content('test query 2')
+    expect(page).to have_content('test query 2')
 
     find(:css, '.wice-grid-query-load-link[title="Load query test query 2"]').click
 
     check_saved_query.call
 
     within '.wice-grid-container' do
-      page.should have_content('test query 2')
+      expect(page).to have_content('test query 2')
     end
 
     delete_all_saved_queries self
-    page.should have_content('Saved query deleted.')
+    expect(page).to have_content('Saved query deleted.')
   end
 end

--- a/spec/features/shared.rb
+++ b/spec/features/shared.rb
@@ -1,12 +1,12 @@
 # encoding: utf-8
 shared_examples 'basic task table specs' do
   it 'is present on the page' do
-    page.should have_selector('div.wice-grid-container table.wice-grid')
+    expect(page).to have_selector('div.wice-grid-container table.wice-grid')
   end
 
   it 'should have a show all link' do
     within 'div.wice-grid-container table.wice-grid' do
-      page.should have_selector('a.wg-show-all-link')
+      expect(page).to have_selector('a.wg-show-all-link')
     end
   end
 
@@ -16,11 +16,11 @@ shared_examples 'basic task table specs' do
     end
 
     within '.wice-grid li.active' do
-      page.should have_content('2')
+      expect(page).to have_content('2')
     end
 
     within '.pagination_status' do
-      page.should have_content('21-40 / 50')
+      expect(page).to have_content('21-40 / 50')
     end
 
     within 'ul.pagination' do
@@ -28,27 +28,27 @@ shared_examples 'basic task table specs' do
     end
 
     within '.wice-grid li.active' do
-      page.should have_content('3')
+      expect(page).to have_content('3')
     end
 
     within '.pagination_status' do
-      page.should have_content('41-50 / 50')
+      expect(page).to have_content('41-50 / 50')
     end
   end
 
   it 'should have a pagination status with page 1 as the current page' do
     within 'div.wice-grid-container table.wice-grid' do
-      page.should have_selector('div.pagination')
+      expect(page).to have_selector('div.pagination')
 
       within 'div.pagination' do
-        page.should have_selector('li.active')
+        expect(page).to have_selector('li.active')
         within 'li.active' do
-          page.should have_content('1')
+          expect(page).to have_content('1')
         end
 
-        page.should have_content('2')
-        page.should have_content('3')
-        page.should have_no_content('4')
+        expect(page).to have_content('2')
+        expect(page).to have_content('3')
+        expect(page).to have_no_content('4')
       end
     end
   end
@@ -59,17 +59,17 @@ shared_examples 'show all and back' do
     click_on 'show all'
 
     within 'div.wice-grid-container table.wice-grid' do
-      page.should have_selector('a.wg-back-to-pagination-link')
+      expect(page).to have_selector('a.wg-back-to-pagination-link')
     end
 
     within '.pagination_status' do
-      page.should have_content('1-50 / 50')
+      expect(page).to have_content('1-50 / 50')
     end
 
     click_on 'back to paginated view'
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end
@@ -77,11 +77,11 @@ end
 shared_examples 'names of columns' do
   it 'should have names of columns' do
     within 'div.wice-grid-container table.wice-grid thead' do
-      page.should have_content('ID')
-      page.should have_content('Title')
-      page.should have_content('Description')
-      page.should have_content('Archived')
-      page.should have_content('Added')
+      expect(page).to have_content('ID')
+      expect(page).to have_content('Title')
+      expect(page).to have_content('Description')
+      expect(page).to have_content('Archived')
+      expect(page).to have_content('Added')
     end
   end
 end
@@ -94,11 +94,11 @@ shared_examples 'sorting ID' do
     sleep 1
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('ID')
+      expect(page).to have_content('ID')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('556')
+      expect(page).to have_content('556')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -107,11 +107,11 @@ shared_examples 'sorting ID' do
     sleep 1
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('ID')
+      expect(page).to have_content('ID')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('507')
+      expect(page).to have_content('507')
     end
 
     within 'ul.pagination' do
@@ -120,15 +120,15 @@ shared_examples 'sorting ID' do
     sleep 1
 
     within '.wice-grid li.active' do
-      page.should have_content('2')
+      expect(page).to have_content('2')
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('ID')
+      expect(page).to have_content('ID')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('527')
+      expect(page).to have_content('527')
     end
   end
 end
@@ -140,11 +140,11 @@ shared_examples 'sorting Title' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('Title')
+      expect(page).to have_content('Title')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('ab')
+      expect(page).to have_content('ab')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -152,11 +152,11 @@ shared_examples 'sorting Title' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Title')
+      expect(page).to have_content('Title')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('voluptatum non')
+      expect(page).to have_content('voluptatum non')
     end
 
     within 'ul.pagination' do
@@ -166,15 +166,15 @@ shared_examples 'sorting Title' do
     sleep 1
 
     within '.wice-grid li.active' do
-      page.should have_content('2')
+      expect(page).to have_content('2')
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Title')
+      expect(page).to have_content('Title')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('quia dignissimos maiores')
+      expect(page).to have_content('quia dignissimos maiores')
     end
   end
 end
@@ -186,11 +186,11 @@ shared_examples 'sorting Description' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('Description')
+      expect(page).to have_content('Description')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('Accusamus voluptas sunt deleniti iusto dolorem repudiandae.')
+      expect(page).to have_content('Accusamus voluptas sunt deleniti iusto dolorem repudiandae.')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -198,11 +198,11 @@ shared_examples 'sorting Description' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Description')
+      expect(page).to have_content('Description')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('Voluptate occaecati quisquam in et qui nostrum eos minus.')
+      expect(page).to have_content('Voluptate occaecati quisquam in et qui nostrum eos minus.')
     end
 
     within 'ul.pagination' do
@@ -210,15 +210,15 @@ shared_examples 'sorting Description' do
     end
 
     within '.wice-grid li.active' do
-      page.should have_content('2')
+      expect(page).to have_content('2')
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Description')
+      expect(page).to have_content('Description')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('Iure tenetur cum aut optio et quia similique debitis.')
+      expect(page).to have_content('Iure tenetur cum aut optio et quia similique debitis.')
     end
   end
 end
@@ -230,11 +230,11 @@ shared_examples 'sorting Archived' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('Archived')
+      expect(page).to have_content('Archived')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -242,11 +242,11 @@ shared_examples 'sorting Archived' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Archived')
+      expect(page).to have_content('Archived')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('Yes')
+      expect(page).to have_content('Yes')
     end
 
     within 'ul.pagination' do
@@ -254,15 +254,15 @@ shared_examples 'sorting Archived' do
     end
 
     within '.wice-grid li.active' do
-      page.should have_content('2')
+      expect(page).to have_content('2')
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Archived')
+      expect(page).to have_content('Archived')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
   end
 end
@@ -274,11 +274,11 @@ shared_examples 'sorting Due Date' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('Due Date')
+      expect(page).to have_content('Due Date')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('2012-06-12')
+      expect(page).to have_content('2012-06-12')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -286,11 +286,11 @@ shared_examples 'sorting Due Date' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Due Date')
+      expect(page).to have_content('Due Date')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('2013-03-30')
+      expect(page).to have_content('2013-03-30')
     end
 
     within 'ul.pagination' do
@@ -298,15 +298,15 @@ shared_examples 'sorting Due Date' do
     end
 
     within '.wice-grid li.active' do
-      page.should have_content('2')
+      expect(page).to have_content('2')
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Due Date')
+      expect(page).to have_content('Due Date')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('2012-12-13')
+      expect(page).to have_content('2012-12-13')
     end
   end
 end
@@ -316,7 +316,7 @@ shared_examples 'sorting ID in all records mode' do
     click_on 'show all'
 
     within '.pagination_status' do
-      page.should have_content('1-50 / 50')
+      expect(page).to have_content('1-50 / 50')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -324,11 +324,11 @@ shared_examples 'sorting ID in all records mode' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('ID')
+      expect(page).to have_content('ID')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('556')
+      expect(page).to have_content('556')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -336,11 +336,11 @@ shared_examples 'sorting ID in all records mode' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('ID')
+      expect(page).to have_content('ID')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('507')
+      expect(page).to have_content('507')
     end
   end
 end
@@ -350,7 +350,7 @@ shared_examples 'sorting Title in all records mode' do
     click_on 'show all'
 
     within '.pagination_status' do
-      page.should have_content('1-50 / 50')
+      expect(page).to have_content('1-50 / 50')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -358,11 +358,11 @@ shared_examples 'sorting Title in all records mode' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('Title')
+      expect(page).to have_content('Title')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('ab')
+      expect(page).to have_content('ab')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -370,11 +370,11 @@ shared_examples 'sorting Title in all records mode' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Title')
+      expect(page).to have_content('Title')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('voluptatum non')
+      expect(page).to have_content('voluptatum non')
     end
   end
 end
@@ -386,7 +386,7 @@ shared_examples 'sorting Description in all records mode' do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-50 / 50')
+      expect(page).to have_content('1-50 / 50')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -394,11 +394,11 @@ shared_examples 'sorting Description in all records mode' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('Description')
+      expect(page).to have_content('Description')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('Accusamus voluptas sunt deleniti iusto dolorem repudiandae.')
+      expect(page).to have_content('Accusamus voluptas sunt deleniti iusto dolorem repudiandae.')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -406,11 +406,11 @@ shared_examples 'sorting Description in all records mode' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Description')
+      expect(page).to have_content('Description')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('Voluptate occaecati quisquam in et qui nostrum eos minus.')
+      expect(page).to have_content('Voluptate occaecati quisquam in et qui nostrum eos minus.')
     end
   end
 end
@@ -420,7 +420,7 @@ shared_examples 'sorting Archived in all records mode' do
     click_on 'show all'
 
     within '.pagination_status' do
-      page.should have_content('1-50 / 50')
+      expect(page).to have_content('1-50 / 50')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -428,11 +428,11 @@ shared_examples 'sorting Archived in all records mode' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('Archived')
+      expect(page).to have_content('Archived')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -440,11 +440,11 @@ shared_examples 'sorting Archived in all records mode' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Archived')
+      expect(page).to have_content('Archived')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('Yes')
+      expect(page).to have_content('Yes')
     end
   end
 end
@@ -454,7 +454,7 @@ shared_examples 'sorting Due Date in all records mode' do
     click_on 'show all'
 
     within '.pagination_status' do
-      page.should have_content('1-50 / 50')
+      expect(page).to have_content('1-50 / 50')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -462,11 +462,11 @@ shared_examples 'sorting Due Date in all records mode' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.asc' do
-      page.should have_content('Due Date')
+      expect(page).to have_content('Due Date')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('2012-06-12')
+      expect(page).to have_content('2012-06-12')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -474,11 +474,11 @@ shared_examples 'sorting Due Date in all records mode' do
     end
 
     within 'div.wice-grid-container table.wice-grid thead th.sorted a.desc' do
-      page.should have_content('Due Date')
+      expect(page).to have_content('Due Date')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('2013-03-30')
+      expect(page).to have_content('2013-03-30')
     end
   end
 end
@@ -521,11 +521,11 @@ shared_examples 'Due Date datepicker filtering' do
 
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2012-07-29')
+      expect(page).to have_content('2012-07-29')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -534,7 +534,7 @@ shared_examples 'Due Date datepicker filtering' do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 35')
+      expect(page).to have_content('1-20 / 35')
     end
 
     within 'ul.pagination' do
@@ -543,7 +543,7 @@ shared_examples 'Due Date datepicker filtering' do
     sleep 1
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2012-07-02')
+      expect(page).to have_content('2012-07-02')
     end
 
     set_datepicker(self, 'grid_f_due_date_fr_date_placeholder', 2012, 6, 28)
@@ -554,7 +554,7 @@ shared_examples 'Due Date datepicker filtering' do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-1 / 1')
+      expect(page).to have_content('1-1 / 1')
     end
 
     find(:css, '#grid_f_due_date_fr_date_view').click
@@ -564,7 +564,7 @@ shared_examples 'Due Date datepicker filtering' do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-10 / 10')
+      expect(page).to have_content('1-10 / 10')
     end
 
     find(:css, '#grid_f_due_date_to_date_view').click
@@ -574,7 +574,7 @@ shared_examples 'Due Date datepicker filtering' do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end
@@ -589,11 +589,11 @@ shared_examples 'Added datepicker filtering' do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 29')
+      expect(page).to have_content('1-20 / 29')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2011-09-13 22:11:12')
+      expect(page).to have_content('2011-09-13 22:11:12')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -602,7 +602,7 @@ shared_examples 'Added datepicker filtering' do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 29')
+      expect(page).to have_content('1-20 / 29')
     end
 
     within 'ul.pagination' do
@@ -611,7 +611,7 @@ shared_examples 'Added datepicker filtering' do
     sleep 2
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2011-09-22 22:11:12')
+      expect(page).to have_content('2011-09-22 22:11:12')
       # page.should have_content('2011-08-14 22:11:12')
     end
 
@@ -619,7 +619,7 @@ shared_examples 'Added datepicker filtering' do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end
@@ -642,11 +642,11 @@ shared_examples 'Due Date standard filtering' do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-16 / 16')
+      expect(page).to have_content('1-16 / 16')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('13 Aug 22:11')
+      expect(page).to have_content('13 Aug 22:11')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -654,12 +654,12 @@ shared_examples 'Due Date standard filtering' do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-16 / 16')
+      expect(page).to have_content('1-16 / 16')
     end
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end
@@ -682,11 +682,11 @@ shared_examples 'Created At standard filtering' do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-14 / 14')
+      expect(page).to have_content('1-14 / 14')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('2011-11-26 22:11:12')
+      expect(page).to have_content('2011-11-26 22:11:12')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -695,14 +695,14 @@ shared_examples 'Created At standard filtering' do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-14 / 14')
+      expect(page).to have_content('1-14 / 14')
     end
 
     find(:css, '#grid_reset_grid_icon').click
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end
@@ -714,43 +714,43 @@ shared_examples 'Description filtering' do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+      expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
     end
 
-    page.should have_content('Vero sit voluptate sed tempora et provident sequi nihil.')
+    expect(page).to have_content('Vero sit voluptate sed tempora et provident sequi nihil.')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Description'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
+      expect(page).to have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
     end
 
-    page.should have_content('Adipisci voluptate sed esse velit.')
+    expect(page).to have_content('Adipisci voluptate sed esse velit.')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
-    page.should have_content('Adipisci voluptate sed esse velit.')
-    page.should have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
+    expect(page).to have_content('Adipisci voluptate sed esse velit.')
+    expect(page).to have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end
@@ -762,11 +762,11 @@ shared_examples 'ID filtering' do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-1 / 1')
+      expect(page).to have_content('1-1 / 1')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('550')
+      expect(page).to have_content('550')
     end
   end
 end
@@ -778,15 +778,15 @@ shared_examples 'ID filtering, range' do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-7 / 7')
+      expect(page).to have_content('1-7 / 7')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('550')
+      expect(page).to have_content('550')
     end
 
     551.upto(556) do |i|
-      page.should have_content(i)
+      expect(page).to have_content(i)
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -794,15 +794,15 @@ shared_examples 'ID filtering, range' do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-7 / 7')
+      expect(page).to have_content('1-7 / 7')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted.active-filter' do
-      page.should have_content('550')
+      expect(page).to have_content('550')
     end
 
     551.upto(556) do |i|
-      page.should have_content(i)
+      expect(page).to have_content(i)
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -810,11 +810,11 @@ shared_examples 'ID filtering, range' do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-7 / 7')
+      expect(page).to have_content('1-7 / 7')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('556')
+      expect(page).to have_content('556')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -822,16 +822,16 @@ shared_examples 'ID filtering, range' do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-7 / 7')
+      expect(page).to have_content('1-7 / 7')
     end
 
     550.upto(556) do |i|
-      page.should have_content(i)
+      expect(page).to have_content(i)
     end
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end
@@ -844,41 +844,41 @@ shared_examples 'ID two limits filtering' do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('507')
+      expect(page).to have_content('507')
     end
 
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted.active-filter' do
-      page.should have_content('507')
+      expect(page).to have_content('507')
     end
 
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.sorted' do
-      page.should have_content('509')
+      expect(page).to have_content('509')
     end
 
     within 'div.wice-grid-container table.wice-grid thead' do
@@ -886,16 +886,16 @@ shared_examples 'ID two limits filtering' do
     end
 
     within '.pagination_status' do
-      page.should have_content('1-3 / 3')
+      expect(page).to have_content('1-3 / 3')
     end
 
-    page.should have_content('507')
-    page.should have_content('508')
-    page.should have_content('509')
+    expect(page).to have_content('507')
+    expect(page).to have_content('508')
+    expect(page).to have_content('509')
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end
@@ -909,26 +909,26 @@ shared_examples 'Description and Title filtering' do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-11 / 11')
+      expect(page).to have_content('1-11 / 11')
     end
 
-    page.should have_content('Inventore iure eos labore ipsum.')
-    page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+    expect(page).to have_content('Inventore iure eos labore ipsum.')
+    expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Description'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-11 / 11')
+      expect(page).to have_content('1-11 / 11')
     end
 
-    page.should have_content('Inventore iure eos labore ipsum.')
-    page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+    expect(page).to have_content('Inventore iure eos labore ipsum.')
+    expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end
@@ -939,22 +939,22 @@ shared_examples 'Archived filtering' do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('Yes')
+      expect(page).to have_content('Yes')
     end
 
     select 'no', from: 'grid_f_archived'
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 46')
+      expect(page).to have_content('1-20 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     within 'ul.pagination' do
@@ -962,16 +962,16 @@ shared_examples 'Archived filtering' do
     end
 
     within '.pagination_status' do
-      page.should have_content('21-40 / 46')
+      expect(page).to have_content('21-40 / 46')
     end
 
     within(first(:css, 'td.active-filter')) do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end
@@ -983,43 +983,43 @@ shared_examples 'Title filtering' do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('sed impedit iste')
+      expect(page).to have_content('sed impedit iste')
     end
 
-    page.should have_content('corporis expedita vel')
+    expect(page).to have_content('corporis expedita vel')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Title'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('corporis expedita vel')
+      expect(page).to have_content('corporis expedita vel')
     end
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
-    page.should have_content('corporis expedita vel')
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('corporis expedita vel')
+    expect(page).to have_content('sed impedit iste')
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end

--- a/spec/features/shared_detached_filters.rb
+++ b/spec/features/shared_detached_filters.rb
@@ -511,22 +511,22 @@ shared_examples "detached_filters" do
     click_button('Submit')
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('Yes')
+      expect(page).to have_content('Yes')
     end
 
     select 'no', :from => 'grid_f_archived'
     click_button('Submit')
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 46')
+      expect(page).to have_content('1-20 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     within 'ul.pagination' do
@@ -536,16 +536,16 @@ shared_examples "detached_filters" do
     sleep 1
 
     within '.pagination_status' do
-      page.should have_content('21-40 / 46')
+      expect(page).to have_content('21-40 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     click_button('Reset')
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -555,43 +555,43 @@ shared_examples "detached_filters" do
     click_button('Submit')
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('sed impedit iste')
+      expect(page).to have_content('sed impedit iste')
     end
 
-    page.should have_content('corporis expedita vel')
+    expect(page).to have_content('corporis expedita vel')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Title'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('corporis expedita vel')
+      expect(page).to have_content('corporis expedita vel')
     end
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
-    page.should have_content('corporis expedita vel')
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('corporis expedita vel')
+    expect(page).to have_content('sed impedit iste')
 
     click_button('Reset')
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -601,43 +601,43 @@ shared_examples "detached_filters" do
     click_button('Submit')
 
     within '.pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+      expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
     end
 
-    page.should have_content('Vero sit voluptate sed tempora et provident sequi nihil.')
+    expect(page).to have_content('Vero sit voluptate sed tempora et provident sequi nihil.')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Description'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
+      expect(page).to have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
     end
 
-    page.should have_content('Adipisci voluptate sed esse velit.')
+    expect(page).to have_content('Adipisci voluptate sed esse velit.')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
-    page.should have_content('Adipisci voluptate sed esse velit.')
-    page.should have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
+    expect(page).to have_content('Adipisci voluptate sed esse velit.')
+    expect(page).to have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
 
     click_button('Reset')
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 
@@ -649,26 +649,26 @@ shared_examples "detached_filters" do
     click_button('Submit')
 
     within '.pagination_status' do
-      page.should have_content('1-11 / 11')
+      expect(page).to have_content('1-11 / 11')
     end
 
-    page.should have_content('Inventore iure eos labore ipsum.')
-    page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+    expect(page).to have_content('Inventore iure eos labore ipsum.')
+    expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Description'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-11 / 11')
+      expect(page).to have_content('1-11 / 11')
     end
 
-    page.should have_content('Inventore iure eos labore ipsum.')
-    page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+    expect(page).to have_content('Inventore iure eos labore ipsum.')
+    expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
 
     click_button('Reset')
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 end

--- a/spec/features/styling_spec.rb
+++ b/spec/features/styling_spec.rb
@@ -7,9 +7,9 @@ describe "styling WiceGrid", :type => :request, :js => true do
   end
 
   it "should have custom css classes" do
-    page.should have_selector('.wice-grid-container table.wice-grid.my-grid')
+    expect(page).to have_selector('.wice-grid-container table.wice-grid.my-grid')
 
-    page.should have_selector('.wice-grid-container thead tr.wice-grid-title-row.my-header')
+    expect(page).to have_selector('.wice-grid-container thead tr.wice-grid-title-row.my-header')
   end
 
 end

--- a/spec/features/two_associations_spec.rb
+++ b/spec/features/two_associations_spec.rb
@@ -13,7 +13,7 @@ describe "two_associations WiceGrid", :type => :request, :js => true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
 
@@ -22,7 +22,7 @@ describe "two_associations WiceGrid", :type => :request, :js => true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-1 / 1')
+      expect(page).to have_content('1-1 / 1')
     end
 
     fill_in('grid_f_companies_name', :with => '')
@@ -30,7 +30,7 @@ describe "two_associations WiceGrid", :type => :request, :js => true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     fill_in('grid_f_companies_name', :with => 'foo')
@@ -38,7 +38,7 @@ describe "two_associations WiceGrid", :type => :request, :js => true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('0')
+      expect(page).to have_content('0')
     end
 
 

--- a/spec/features/upper_pagination_panel_request_spec.rb
+++ b/spec/features/upper_pagination_panel_request_spec.rb
@@ -12,10 +12,10 @@ describe "upper pagination panel WiceGrid", :type => :request do
   end
 
   it "upper pagination panel should be present" do
-    page.should have_selector('table.wice-grid thead tr td .pagination li.active')
+    expect(page).to have_selector('table.wice-grid thead tr td .pagination li.active')
 
     within 'table.wice-grid thead tr td .pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
   end
 

--- a/spec/features/when_filtered_spec.rb
+++ b/spec/features/when_filtered_spec.rb
@@ -8,9 +8,9 @@ describe "when_filtered WiceGrid",  :js => true do
 
 
   it "the filter panel is hidden by default" do
-    lambda{
+    expect{
       fill_in('grid_f_description', :with => 've')
-    }.should raise_error(Capybara::ElementNotFound)
+    }.to raise_error(Capybara::ElementNotFound)
   end
 
   it "should filter by Description" do
@@ -23,45 +23,45 @@ describe "when_filtered WiceGrid",  :js => true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+      expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
     end
 
-    page.should have_content('Vero sit voluptate sed tempora et provident sequi nihil.')
+    expect(page).to have_content('Vero sit voluptate sed tempora et provident sequi nihil.')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Description'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
+      expect(page).to have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
     end
 
-    page.should have_content('Adipisci voluptate sed esse velit.')
+    expect(page).to have_content('Adipisci voluptate sed esse velit.')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-12 / 12')
+      expect(page).to have_content('1-12 / 12')
     end
 
 
-    page.should have_content('Adipisci voluptate sed esse velit.')
-    page.should have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
+    expect(page).to have_content('Adipisci voluptate sed esse velit.')
+    expect(page).to have_content('Ad sunt vel maxime labore temporibus incidunt quidem.')
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
   end
@@ -79,26 +79,26 @@ describe "when_filtered WiceGrid",  :js => true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-11 / 11')
+      expect(page).to have_content('1-11 / 11')
     end
 
-    page.should have_content('Inventore iure eos labore ipsum.')
-    page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+    expect(page).to have_content('Inventore iure eos labore ipsum.')
+    expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Description'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-11 / 11')
+      expect(page).to have_content('1-11 / 11')
     end
 
-    page.should have_content('Inventore iure eos labore ipsum.')
-    page.should have_content('Velit atque sapiente aspernatur sint fuga.')
+    expect(page).to have_content('Inventore iure eos labore ipsum.')
+    expect(page).to have_content('Velit atque sapiente aspernatur sint fuga.')
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
 
@@ -113,22 +113,22 @@ describe "when_filtered WiceGrid",  :js => true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-4 / 4')
+      expect(page).to have_content('1-4 / 4')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('Yes')
+      expect(page).to have_content('Yes')
     end
 
     select 'no', :from => 'grid_f_archived'
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-20 / 46')
+      expect(page).to have_content('1-20 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
 
@@ -137,16 +137,16 @@ describe "when_filtered WiceGrid",  :js => true do
     end
 
     within '.pagination_status' do
-      page.should have_content('21-40 / 46')
+      expect(page).to have_content('21-40 / 46')
     end
 
     within first(:css, 'td.active-filter') do
-      page.should have_content('No')
+      expect(page).to have_content('No')
     end
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
 
@@ -162,45 +162,45 @@ describe "when_filtered WiceGrid",  :js => true do
     find(:css, '#grid_submit_grid_icon').click
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('sed impedit iste')
+      expect(page).to have_content('sed impedit iste')
     end
 
-    page.should have_content('corporis expedita vel')
+    expect(page).to have_content('corporis expedita vel')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'Title'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
 
     within 'div.wice-grid-container table.wice-grid tbody tr:first-child td.active-filter' do
-      page.should have_content('corporis expedita vel')
+      expect(page).to have_content('corporis expedita vel')
     end
 
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('sed impedit iste')
 
     within 'div.wice-grid-container table.wice-grid thead' do
       click_on 'ID'
     end
 
     within '.pagination_status' do
-      page.should have_content('1-2 / 2')
+      expect(page).to have_content('1-2 / 2')
     end
 
 
-    page.should have_content('corporis expedita vel')
-    page.should have_content('sed impedit iste')
+    expect(page).to have_content('corporis expedita vel')
+    expect(page).to have_content('sed impedit iste')
 
     find(:css, '#grid_reset_grid_icon').click
     within '.pagination_status' do
-      page.should have_content('1-20 / 50')
+      expect(page).to have_content('1-20 / 50')
     end
 
   end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
 describe Company do
-  it { should have_many(:supplier_projects)}
-  it { should have_many(:customer_projects)}
+  it { is_expected.to have_many(:supplier_projects)}
+  it { is_expected.to have_many(:customer_projects)}
 end

--- a/spec/models/priority_spec.rb
+++ b/spec/models/priority_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
 describe Priority do
-  it { should have_many(:tasks)}
+  it { is_expected.to have_many(:tasks)}
 
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 describe Project do
-  it {should have_many(:tasks)}
-  it { should have_many(:tasks)}
-  it { should have_many(:user_project_participations)}
-  it { should have_many(:users)}
-  it { should have_many(:versions)}
-  it { should belong_to(:customer)}
-  it { should belong_to(:supplier)}
+  it {is_expected.to have_many(:tasks)}
+  it { is_expected.to have_many(:tasks)}
+  it { is_expected.to have_many(:user_project_participations)}
+  it { is_expected.to have_many(:users)}
+  it { is_expected.to have_many(:versions)}
+  it { is_expected.to belong_to(:customer)}
+  it { is_expected.to belong_to(:supplier)}
 end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
 describe Status do
-  it {should have_many(:tasks) }
+  it {is_expected.to have_many(:tasks) }
 end
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 describe Task do
-  it { should belong_to(:created_by)}
-  it { should belong_to(:project)}
-  it { should belong_to(:priority)}
-  it { should belong_to(:status)}
-  it { should belong_to(:relevant_version)}
-  it { should belong_to(:expected_version)}
+  it { is_expected.to belong_to(:created_by)}
+  it { is_expected.to belong_to(:project)}
+  it { is_expected.to belong_to(:priority)}
+  it { is_expected.to belong_to(:status)}
+  it { is_expected.to belong_to(:relevant_version)}
+  it { is_expected.to belong_to(:expected_version)}
 
-  it { should have_and_belong_to_many(:assigned_users)}
+  it { is_expected.to have_and_belong_to_many(:assigned_users)}
 end

--- a/spec/models/user_project_participation_spec.rb
+++ b/spec/models/user_project_participation_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe UserProjectParticipation do
-  it { should belong_to(:user)}
-  it { should belong_to(:project)}
-  it { should belong_to(:project_role)}
+  it { is_expected.to belong_to(:user)}
+  it { is_expected.to belong_to(:project)}
+  it { is_expected.to belong_to(:project_role)}
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 describe User do
-  it { should have_many(:created_tasks)}
+  it { is_expected.to have_many(:created_tasks)}
 
 
-  it { should have_and_belong_to_many(:assigned_tasks)}
+  it { is_expected.to have_and_belong_to_many(:assigned_tasks)}
 
 
-  it { should have_many(:user_project_participations)}
-  it { should have_many(:projects)}
+  it { is_expected.to have_many(:user_project_participations)}
+  it { is_expected.to have_many(:projects)}
 end

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 describe Version do
-  it { should belong_to(:project)}
+  it { is_expected.to belong_to(:project)}
 end


### PR DESCRIPTION
Closes #22 

This conversion is done by Transpec 3.3.0 with the following command:
    transpec -f

* 681 conversions
    from: obj.should
      to: expect(obj).to

* 26 conversions
    from: it { should ... }
      to: it { is_expected.to ... }

* 2 conversions
    from: -> { }.should
      to: expect { }.to

* 2 conversions
    from: lambda { }.should
      to: expect { }.to

For more details: https://github.com/yujinakayama/transpec#supported-conversions