### PR TITLE
Do not count spec folder with SimpleCov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,9 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
     Coveralls::SimpleCov::Formatter,
     SimpleCov::Formatter::HTMLFormatter
 ])
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/spec/"
+end
 
 begin
   require 'support/active_record'


### PR DESCRIPTION
All specs were obviously 100% covered, which inflated the coverage from 85% to 92%