### PR TITLE
Advertise Rails 5.2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix deprecation (in Rails 5.2) regarding "Dangerous query methods" in `order` clauses. Note that when using the `custom_order` option you must pass a value acceptable for ActiveRecord's `order` method, otherwise you will receive the same warning. - [#41](https://github.com/patricklindsay/wice_grid/pull/41)
 * Add support for using `Arel::Attributes::Attribute`s with the `custom_order` option. - [#41](https://github.com/patricklindsay/wice_grid/pull/41)
 * Added `sort_by` option to column to allow arbitrary, Ruby-based ordering. - [#3](https://github.com/patricklindsay/wice_grid/pull/3)
+* Added Rails 5.2 support
 
 ## 4.0.1 (31 May, 2018)
 


### PR DESCRIPTION
Been running wice_grid with Rails 5.2 for a couple weeks now with no issue. We have it in the automated tests as well. So add a note to the changelog.

Closes #11.