### PR TITLE
Filter datetime columns

### DIFF
--- a/lib/wice/active_record_column_wrapper.rb
+++ b/lib/wice/active_record_column_wrapper.rb
@@ -118,5 +118,9 @@ module Wice
     def alias_or_table_name(table_alias) #:nodoc:
       table_alias || @column.model.table_name
     end
+
+    def type
+      @column.type
+    end
   end
 end

--- a/lib/wice/columns/common_js_date_datetime_conditions_generator_mixin.rb
+++ b/lib/wice/columns/common_js_date_datetime_conditions_generator_mixin.rb
@@ -4,24 +4,27 @@ module Wice
 
       def generate_conditions(table_alias, opts)   #:nodoc:
 
-        datetime = @column_type == :datetime || @column_type == :timestamp
+        # Is this a datetime based column?
+        datetime = @column_wrapper.type == :datetime
 
         conditions = [[]]
         if opts[:fr]
           conditions[0] << " #{@column_wrapper.alias_or_table_name(table_alias)}.#{@column_wrapper.name} >= ? "
-          date = opts[:fr].to_date
-          if datetime
-            date = date.to_datetime
+          date = if datetime
+            opts[:fr].to_datetime
+          else
+            opts[:fr].to_date
           end
           conditions << date
         end
 
         if opts[:to]
           op = '<='
-          date = opts[:to].to_date
           if datetime
-            date = (date + 1).to_datetime
+            date = (opts[:to] + 1.day).to_datetime
             op = '<'
+          else
+            date = opts[:to].to_date
           end
           conditions[0] << " #{@column_wrapper.alias_or_table_name(table_alias)}.#{@column_wrapper.name} #{op} ? "
           conditions << date


### PR DESCRIPTION
Datetime columns such as created_at were not filtering properly as the time component was being stripped when dates were sent through. Because the datetimes were stored in UTC the results were off by several hours (5 in the case of the application being in EST). This code uses the database column type rather than the filter type to determine how to construct the query. 