### PR TITLE
Update wice_grid.gemspec for Kaminari dependency

### DIFF
--- a/wice_grid.gemspec
+++ b/wice_grid.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.date          = '2018-11-28'
 
   s.add_dependency 'rails', '~> 5.0', '< 5.3'
-  s.add_dependency 'kaminari',          ['~> 1.1.0']
+  s.add_dependency 'kaminari',          ['~> 1.2.1']
   s.add_dependency 'coffee-rails',      ['> 3.2']
 
   s.add_development_dependency('rake',  '~> 10.1')


### PR DESCRIPTION
Kaminari v1.2.1, released last week, fixes a security issue (changelog) but I can't update it because wice_grid requires version ~> 1.1.0.
See issue: https://github.com/patricklindsay/wice_grid/issues/78