### PR TITLE
Boyscout: loosen lock on Kaminari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Fix bug in "Dangerous query methods" deprecation warning fix in custom order when using Arel.sql
+* Loosen lock on Kaminari
 
 ## 4.1.0 (28 November, 2018)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     wice_grid (4.1.0)
       coffee-rails (> 3.2)
-      kaminari (~> 1.1.0)
+      kaminari (~> 1.1)
       rails (~> 5.0, < 5.3)
 
 GEM
@@ -90,7 +90,7 @@ GEM
     ffi (1.9.23)
     font-awesome-sass (4.4.0)
       sass (>= 3.2)
-    globalid (0.4.1)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.0.4)
       temple (>= 0.8.0)
@@ -139,7 +139,7 @@ GEM
     minitest (5.11.1)
     multi_json (1.13.1)
     multi_xml (0.6.0)
-    nio4r (2.3.1)
+    nio4r (2.5.2)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     poltergeist (1.18.1)

--- a/gemfiles/rails_5.0.gemfile.lock
+++ b/gemfiles/rails_5.0.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     wice_grid (4.1.0)
       coffee-rails (> 3.2)
-      kaminari (~> 1.1.0)
+      kaminari (~> 1.1)
       rails (~> 5.0, < 5.3)
 
 GEM

--- a/gemfiles/rails_5.1.gemfile.lock
+++ b/gemfiles/rails_5.1.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     wice_grid (4.1.0)
       coffee-rails (> 3.2)
-      kaminari (~> 1.1.0)
+      kaminari (~> 1.1)
       rails (~> 5.0, < 5.3)
 
 GEM

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     wice_grid (4.1.0)
       coffee-rails (> 3.2)
-      kaminari (~> 1.1.0)
+      kaminari (~> 1.1)
       rails (~> 5.0, < 5.3)
 
 GEM
@@ -76,9 +76,9 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
     coderay (1.1.2)
-    coffee-rails (4.2.2)
+    coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
+      railties (>= 5.2.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs

--- a/wice_grid.gemspec
+++ b/wice_grid.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.date          = '2018-11-28'
 
   s.add_dependency 'rails', '~> 5.0', '< 5.3'
-  s.add_dependency 'kaminari',          ['~> 1.1.0']
+  s.add_dependency 'kaminari',          ['~> 1.1']
   s.add_dependency 'coffee-rails',      ['> 3.2']
 
   s.add_development_dependency('rake',  '~> 10.1')


### PR DESCRIPTION
So we don't block minor version upgrades (which shouldn't have breaking changes)